### PR TITLE
Always find Dream models from the primary database, not

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic-workers",
   "description": "Background job system for Psychic applications",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": "RVO Health",
   "repository": {
     "type": "git",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -713,7 +713,7 @@ export class Background {
         }
 
         if (dreamClass) {
-          const modelInstance = await dreamClass.find(id)
+          const modelInstance = await dreamClass.connection('primary').find(id)
           if (!modelInstance) return
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access


### PR DESCRIPTION
the read replica, even when the model is ReplicaSafe, since backgrounding is often performed in a model lifecycle hook, and we don't want the background job to pick up outdated (or not even saved, in the case of AfterCreateCommit) model data.