### PR TITLE
add jobId to delayed job api

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic-workers",
   "description": "Background job system for Psychic applications",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "author": "RVO Health",
   "repository": {
     "type": "git",

--- a/spec/unit/background/a-backgrounded-model.spec.ts
+++ b/spec/unit/background/a-backgrounded-model.spec.ts
@@ -34,7 +34,7 @@ describe('a backgrounded model', () => {
       })
 
       it('adds the job to the queue corresponding to the workstream name with the workstream name as the group ID, and moves the priority into the group object', async () => {
-        const spy = vi.spyOn(background.queues[1], 'add').mockResolvedValue({} as Job)
+        const spy = vi.spyOn(background.queues[1]!, 'add').mockResolvedValue({} as Job)
         await User.background('classRunInBG', 'bottlearum')
 
         expect(spy).toHaveBeenCalledWith(
@@ -73,7 +73,7 @@ describe('a backgrounded model', () => {
 
       it('adds the job to the queue corresponding to the workstream name with the workstream name as the group ID, and moves the priority into the group object', async () => {
         const user = await User.create({ email: 'a@b.com' })
-        const spy = vi.spyOn(background.queues[1], 'add').mockResolvedValue({} as Job)
+        const spy = vi.spyOn(background.queues[1]!, 'add').mockResolvedValue({} as Job)
         await user.background('instanceRunInBG', 'bottlearum')
 
         expect(spy).toHaveBeenCalledWith(
@@ -93,7 +93,7 @@ describe('a backgrounded model', () => {
   describe('.backgroundWithDelay', () => {
     it('calls the static method, passing args', async () => {
       const spy = vi.spyOn(User, 'classRunInBG').mockImplementation(async () => {})
-      await User.backgroundWithDelay(25, 'classRunInBG', 'bottlearum')
+      await User.backgroundWithDelay({ seconds: 25 }, 'classRunInBG', 'bottlearum')
       expect(spy).toHaveBeenCalledWith('bottlearum', expect.any(Job))
     })
 
@@ -108,8 +108,8 @@ describe('a backgrounded model', () => {
       })
 
       it('adds the job to the queue corresponding to the workstream name with the workstream name as the group ID, and moves the priority into the group object', async () => {
-        const spy = vi.spyOn(background.queues[1], 'add').mockResolvedValue({} as Job)
-        await User.backgroundWithDelay(15, 'classRunInBG', 'bottlearum')
+        const spy = vi.spyOn(background.queues[1]!, 'add').mockResolvedValue({} as Job)
+        await User.backgroundWithDelay({ seconds: 15, jobId: 'myjob' }, 'classRunInBG', 'bottlearum')
 
         expect(spy).toHaveBeenCalledWith(
           'BackgroundJobQueueStaticJob',
@@ -119,7 +119,7 @@ describe('a backgrounded model', () => {
             importKey: undefined,
             method: 'classRunInBG',
           },
-          { delay: 15000, group: { id: 'snazzy', priority: 1 } },
+          { delay: 15000, jobId: 'myjob', group: { id: 'snazzy', priority: 1 } },
         )
       })
     })
@@ -129,7 +129,7 @@ describe('a backgrounded model', () => {
     it('calls the instance method, passing args', async () => {
       const user = await User.create({ email: 'a@b.com' })
       const spy = vi.spyOn(User.prototype, 'instanceMethodToTest').mockImplementation(async () => {})
-      await user.backgroundWithDelay(15, 'instanceRunInBG', 'bottlearum')
+      await user.backgroundWithDelay({ seconds: 15, jobId: 'myjob' }, 'instanceRunInBG', 'bottlearum')
       expect(spy).toHaveBeenCalledWith('bottlearum', expect.any(Job))
     })
 
@@ -137,7 +137,9 @@ describe('a backgrounded model', () => {
       it('does not throw an error', async () => {
         const user = await User.create({ email: 'a@b.com' })
         await user.destroy()
-        await expect(user.backgroundWithDelay(15, 'instanceRunInBG', 'bottlearum')).resolves.not.toThrow()
+        await expect(
+          user.backgroundWithDelay({ seconds: 15, jobId: 'myjob' }, 'instanceRunInBG', 'bottlearum'),
+        ).resolves.not.toThrow()
       })
     })
 
@@ -152,10 +154,10 @@ describe('a backgrounded model', () => {
       })
 
       it('adds the job to the queue corresponding to the workstream name with the workstream name as the group ID, and moves the priority into the group object', async () => {
-        const spy = vi.spyOn(background.queues[1], 'add').mockResolvedValue({} as Job)
+        const spy = vi.spyOn(background.queues[1]!, 'add').mockResolvedValue({} as Job)
         const user = await User.create({ email: 'a@b.com' })
 
-        await user.backgroundWithDelay(7, 'instanceRunInBG', 'bottlearum')
+        await user.backgroundWithDelay({ seconds: 7, jobId: 'myjob' }, 'instanceRunInBG', 'bottlearum')
 
         expect(spy).toHaveBeenCalledWith(
           'BackgroundJobQueueModelInstanceJob',
@@ -165,7 +167,7 @@ describe('a backgrounded model', () => {
             id: user.id,
             method: 'instanceRunInBG',
           },
-          { delay: 7000, group: { id: 'snazzy', priority: 1 } },
+          { delay: 7000, jobId: 'myjob', group: { id: 'snazzy', priority: 1 } },
         )
       })
     })

--- a/spec/unit/background/a-backgrounded-service.spec.ts
+++ b/spec/unit/background/a-backgrounded-service.spec.ts
@@ -33,7 +33,7 @@ describe('a backgrounded service', () => {
         process.env.REALLY_TEST_BACKGROUND_QUEUE = '1'
         background.connect()
 
-        spy = vi.spyOn(background.queues[0], 'add').mockResolvedValue({} as Job)
+        spy = vi.spyOn(background.queues[0]!, 'add').mockResolvedValue({} as Job)
       })
 
       afterEach(() => {
@@ -115,7 +115,7 @@ describe('a backgrounded service', () => {
       })
 
       it('adds the job to the queue corresponding to the workstream name with the workstream name as the group ID, and moves the priority into the group object', async () => {
-        const spy = vi.spyOn(background.queues[1], 'add').mockResolvedValue({} as Job)
+        const spy = vi.spyOn(background.queues[1]!, 'add').mockResolvedValue({} as Job)
         await LastDummyServiceInNamedWorkstream.background('classRunInBG', 'bottlearum')
 
         expect(spy).toHaveBeenCalledWith(
@@ -135,7 +135,7 @@ describe('a backgrounded service', () => {
   describe('.backgroundWithDelay', () => {
     it('calls the static method, passing args', async () => {
       const spy = vi.spyOn(DummyService, 'classRunInBG').mockImplementation(async () => {})
-      await DummyService.backgroundWithDelay(25, 'classRunInBG', 'bottlearum')
+      await DummyService.backgroundWithDelay({ seconds: 25, jobId: 'myjob' }, 'classRunInBG', 'bottlearum')
       expect(spy).toHaveBeenCalledWith('bottlearum', expect.any(Job))
     })
 
@@ -143,14 +143,14 @@ describe('a backgrounded service', () => {
       let spy: MockInstance
 
       const subject = async () => {
-        await serviceClass.backgroundWithDelay(7, 'classRunInBG', 'bottlearum')
+        await serviceClass.backgroundWithDelay({ seconds: 7, jobId: 'myjob' }, 'classRunInBG', 'bottlearum')
       }
 
       beforeEach(() => {
         process.env.REALLY_TEST_BACKGROUND_QUEUE = '1'
         background.connect()
 
-        spy = vi.spyOn(background.queues[0], 'add').mockResolvedValue({} as Job)
+        spy = vi.spyOn(background.queues[0]!, 'add').mockResolvedValue({} as Job)
       })
 
       afterEach(() => {
@@ -171,7 +171,7 @@ describe('a backgrounded service', () => {
             args: ['bottlearum'],
             method: 'classRunInBG',
           },
-          { delay: 7000, priority: priorityLevel },
+          { delay: 7000, jobId: 'myjob', priority: priorityLevel },
         )
       }
 
@@ -231,8 +231,12 @@ describe('a backgrounded service', () => {
       })
 
       it('adds the job to the queue corresponding to the workstream name with the workstream name as the group ID, and moves the priority into the group object', async () => {
-        const spy = vi.spyOn(background.queues[1], 'add').mockResolvedValue({} as Job)
-        await LastDummyServiceInNamedWorkstream.backgroundWithDelay(7, 'classRunInBG', 'bottlearum')
+        const spy = vi.spyOn(background.queues[1]!, 'add').mockResolvedValue({} as Job)
+        await LastDummyServiceInNamedWorkstream.backgroundWithDelay(
+          { seconds: 7, jobId: 'myjob' },
+          'classRunInBG',
+          'bottlearum',
+        )
 
         expect(spy).toHaveBeenCalledWith(
           'BackgroundJobQueueStaticJob',
@@ -242,7 +246,7 @@ describe('a backgrounded service', () => {
             importKey: undefined,
             method: 'classRunInBG',
           },
-          { delay: 7000, group: { id: 'snazzy', priority: 4 } },
+          { delay: 7000, jobId: 'myjob', group: { id: 'snazzy', priority: 4 } },
         )
       })
     })

--- a/spec/unit/background/a-scheduled-service.spec.ts
+++ b/spec/unit/background/a-scheduled-service.spec.ts
@@ -20,7 +20,7 @@ describe('a scheduled service', () => {
 
     function expectAddedToQueueWithPriority(priority: BackgroundQueuePriority, priorityLevel: number) {
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(background.queues[0].add).toHaveBeenCalledWith(
+      expect(background.queues[0]!.add).toHaveBeenCalledWith(
         'BackgroundJobQueueStaticJob',
         {
           globalName: `services/${serviceClass.name}`,
@@ -42,7 +42,7 @@ describe('a scheduled service', () => {
       process.env.REALLY_TEST_BACKGROUND_QUEUE = '1'
       background.connect()
 
-      vi.spyOn(background.queues[0], 'add').mockResolvedValue({} as Job)
+      vi.spyOn(background.queues[0]!, 'add').mockResolvedValue({} as Job)
     })
 
     afterEach(() => {

--- a/spec/unit/helpers/durationToSeconds.spec.ts
+++ b/spec/unit/helpers/durationToSeconds.spec.ts
@@ -1,0 +1,52 @@
+import durationToSeconds from '../../../src/helpers/durationToSeconds.js'
+
+describe('durationToSeconds', () => {
+  context('with a blank object', () => {
+    it('returns undefined', () => {
+      const duration = durationToSeconds({})
+      expect(duration).toEqual(0)
+    })
+  })
+
+  context('seconds', () => {
+    it('returns number', () => {
+      const duration = durationToSeconds({ seconds: 31 })
+      expect(duration).toEqual(31)
+    })
+  })
+
+  context('minutes', () => {
+    it('returns number * 60', () => {
+      const duration = durationToSeconds({ minutes: 1 })
+      expect(duration).toEqual(60)
+    })
+  })
+
+  context('hours', () => {
+    it('returns number * 60 * 60', () => {
+      const duration = durationToSeconds({ hours: 1 })
+      expect(duration).toEqual(60 * 60)
+    })
+  })
+
+  context('days', () => {
+    it('returns number * 60 * 60 * 24', () => {
+      const duration = durationToSeconds({ days: 31 })
+      expect(duration).toEqual(31 * 60 * 60 * 24)
+    })
+  })
+
+  context('with multiple fields set', () => {
+    it('combines multiple fields to yield seconds', () => {
+      const duration = durationToSeconds({ days: 1, hours: 1, minutes: 1, seconds: 1 })
+
+      const daysSeconds = 60 * 60 * 24
+      const hoursSeconds = 60 * 60
+      const minutesSeconds = 60
+      const secondsSeconds = 1
+      const expectedDurationSeconds = daysSeconds + hoursSeconds + minutesSeconds + secondsSeconds
+
+      expect(duration).toEqual(expectedDurationSeconds)
+    })
+  })
+})

--- a/src/background/BaseBackgroundedModel.ts
+++ b/src/background/BaseBackgroundedModel.ts
@@ -1,8 +1,9 @@
 import { Dream } from '@rvoh/dream'
-import { BackgroundJobConfig } from '../types/background.js'
+import { BackgroundJobConfig, DelayedJobOpts } from '../types/background.js'
 import { FunctionPropertyNames } from '../types/utils.js'
 import { BackgroundableMethodArgs } from './BaseBackgroundedService.js'
 import background from './index.js'
+import durationToSeconds from '../helpers/durationToSeconds.js'
 
 export default class BaseBackgroundedModel extends Dream {
   /**
@@ -92,12 +93,13 @@ export default class BaseBackgroundedModel extends Dream {
     MethodName extends PsychicBackgroundedModelStaticMethods<T & typeof BaseBackgroundedModel>,
     MethodFunc extends T[MethodName & keyof T],
     MethodArgs extends BackgroundableMethodArgs<MethodFunc>,
-  >(this: T, delaySeconds: number, methodName: MethodName, ...args: MethodArgs) {
+  >(this: T, delay: DelayedJobOpts, methodName: MethodName, ...args: MethodArgs) {
     const safeThis: typeof BaseBackgroundedModel = this as typeof BaseBackgroundedModel
 
     return await background.staticMethod(safeThis, methodName, {
       globalName: safeThis.globalName,
-      delaySeconds,
+      delaySeconds: durationToSeconds(delay),
+      jobId: delay.jobId,
       args,
       jobConfig: safeThis.backgroundJobConfig,
     })
@@ -174,12 +176,13 @@ export default class BaseBackgroundedModel extends Dream {
     MethodName extends PsychicBackgroundedServiceInstanceMethods<T & BaseBackgroundedModel>,
     MethodFunc extends T[MethodName & keyof T],
     MethodArgs extends BackgroundableMethodArgs<MethodFunc>,
-  >(this: T, delaySeconds: number, methodName: MethodName, ...args: MethodArgs) {
+  >(this: T, delay: DelayedJobOpts, methodName: MethodName, ...args: MethodArgs) {
     const safeThis: BaseBackgroundedModel = this as BaseBackgroundedModel
 
     return await background.modelInstanceMethod(safeThis, methodName, {
       args,
-      delaySeconds,
+      delaySeconds: durationToSeconds(delay),
+      jobId: delay.jobId,
       jobConfig: safeThis.backgroundJobConfig,
     })
   }

--- a/src/background/BaseBackgroundedService.ts
+++ b/src/background/BaseBackgroundedService.ts
@@ -1,8 +1,9 @@
 import { GlobalNameNotSet } from '@rvoh/dream'
 import { Job } from 'bullmq'
-import { BackgroundJobConfig } from '../types/background.js'
+import { BackgroundJobConfig, DelayedJobOpts } from '../types/background.js'
 import { FunctionPropertyNames } from '../types/utils.js'
 import background from './index.js'
+import durationToSeconds from '../helpers/durationToSeconds.js'
 
 export default class BaseBackgroundedService {
   /**
@@ -104,12 +105,13 @@ export default class BaseBackgroundedService {
     MethodName extends PsychicBackgroundedServiceStaticMethods<T & typeof BaseBackgroundedService>,
     MethodFunc extends T[MethodName & keyof T],
     MethodArgs extends BackgroundableMethodArgs<MethodFunc>,
-  >(this: T, delaySeconds: number, methodName: MethodName, ...args: MethodArgs) {
+  >(this: T, delay: DelayedJobOpts, methodName: MethodName, ...args: MethodArgs) {
     const safeThis: typeof BaseBackgroundedService = this as typeof BaseBackgroundedService
 
     return await background.staticMethod(safeThis, methodName, {
       globalName: safeThis.globalName,
-      delaySeconds,
+      delaySeconds: durationToSeconds(delay),
+      jobId: delay.jobId,
       args,
       jobConfig: safeThis.backgroundJobConfig,
     })

--- a/src/helpers/durationToSeconds.ts
+++ b/src/helpers/durationToSeconds.ts
@@ -1,0 +1,10 @@
+import { DelayedJobDuration } from '../types/background.js'
+
+export default function durationToSeconds(duration: DelayedJobDuration) {
+  return (
+    (duration.seconds ? duration.seconds : 0) +
+    (duration.minutes ? duration.minutes * 60 : 0) +
+    (duration.hours ? duration.hours * 60 * 60 : 0) +
+    (duration.days ? duration.days * 60 * 60 * 24 : 0)
+  )
+}

--- a/src/types/background.ts
+++ b/src/types/background.ts
@@ -41,6 +41,22 @@ export interface BackgroundJobData {
   globalName?: string
 }
 
+export type DelayedJobOpts = DelayedJobDuration & {
+  /**
+   * a unique identifier for your job. this identifier will be
+   * used to debounce, leveraging the internal throttling mechanisms
+   * provided by BullMQ
+   */
+  jobId?: string
+}
+
+export interface DelayedJobDuration {
+  seconds?: number
+  minutes?: number
+  hours?: number
+  days?: number
+}
+
 export type JobTypes =
   | 'BackgroundJobQueueFunctionJob'
   | 'BackgroundJobQueueStaticJob'


### PR DESCRIPTION
This enables devs to debounce their calls to the background, using a unique identifier key that can be provided as the `jobId` param. Additionally, duration can now be an expression containing many different units of time.