### PR TITLE
add ability to manually process background jobs in specs

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -28,7 +28,14 @@
         "description": "The request has succeeded, but there is no content to render"
       },
       "BadRequest": {
-        "description": "The server would not process the request due to something the server considered to be a client error"
+        "description": "The server would not process the request due to something the server considered to be a client error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ValidationErrors"
+            }
+          }
+        }
       },
       "Unauthorized": {
         "description": "The request was not successful because it lacks valid authentication credentials for the requested resource"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic-workers",
   "description": "Background job system for Psychic applications",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "author": "RVO Health",
   "repository": {
     "type": "git",
@@ -45,7 +45,7 @@
     "@eslint/js": "=9.0.0",
     "@rvoh/dream": "^0.39.0",
     "@rvoh/dream-spec-helpers": "^0.2.4",
-    "@rvoh/psychic": "^0.31.0",
+    "@rvoh/psychic": "^0.35.1",
     "@rvoh/psychic-spec-helpers": "^0.6.0",
     "@socket.io/redis-adapter": "^8.3.0",
     "@socket.io/redis-emitter": "^5.1.0",
@@ -70,7 +70,7 @@
     "typedoc": "^0.26.6",
     "typescript": "^5.8.2",
     "typescript-eslint": "=7.18.0",
-    "vitest": "^3.1.1"
+    "vitest": "^3.1.3"
   },
   "packageManager": "yarn@4.7.0"
 }

--- a/spec/unit/background/a-backgrounded-model.spec.ts
+++ b/spec/unit/background/a-backgrounded-model.spec.ts
@@ -1,6 +1,10 @@
 import { Job } from 'bullmq'
 import { background } from '../../../src/index.js'
 import User from '../../../test-app/src/app/models/User.js'
+import PsychicAppWorkers, {
+  PsychicWorkersAppTestInvocationType,
+} from '../../../src/psychic-app-workers/index.js'
+import WorkerTestUtils from '../../../src/test-utils/WorkerTestUtils.js'
 
 describe('a backgrounded model', () => {
   describe('.background', () => {
@@ -24,13 +28,19 @@ describe('a backgrounded model', () => {
     })
 
     context('priority and named workstream', () => {
-      beforeEach(() => {
-        process.env.REALLY_TEST_BACKGROUND_QUEUE = '1'
-        background.connect()
+      let originalTestInvocation: PsychicWorkersAppTestInvocationType
+
+      beforeEach(async () => {
+        const workersApp = PsychicAppWorkers.getOrFail()
+        originalTestInvocation = workersApp.testInvocation
+        workersApp.set('testInvocation', 'manual')
+
+        await WorkerTestUtils.clean()
       })
 
       afterEach(() => {
-        process.env.REALLY_TEST_BACKGROUND_QUEUE = undefined
+        const workersApp = PsychicAppWorkers.getOrFail()
+        workersApp.set('testInvocation', originalTestInvocation)
       })
 
       it('adds the job to the queue corresponding to the workstream name with the workstream name as the group ID, and moves the priority into the group object', async () => {
@@ -62,13 +72,19 @@ describe('a backgrounded model', () => {
     })
 
     context('priority and named workstream', () => {
-      beforeEach(() => {
-        process.env.REALLY_TEST_BACKGROUND_QUEUE = '1'
-        background.connect()
+      let originalTestInvocation: PsychicWorkersAppTestInvocationType
+
+      beforeEach(async () => {
+        const workersApp = PsychicAppWorkers.getOrFail()
+        originalTestInvocation = workersApp.testInvocation
+        workersApp.set('testInvocation', 'manual')
+
+        await WorkerTestUtils.clean()
       })
 
       afterEach(() => {
-        process.env.REALLY_TEST_BACKGROUND_QUEUE = undefined
+        const workersApp = PsychicAppWorkers.getOrFail()
+        workersApp.set('testInvocation', originalTestInvocation)
       })
 
       it('adds the job to the queue corresponding to the workstream name with the workstream name as the group ID, and moves the priority into the group object', async () => {
@@ -98,13 +114,24 @@ describe('a backgrounded model', () => {
     })
 
     context('priority and named workstream', () => {
-      beforeEach(() => {
-        process.env.REALLY_TEST_BACKGROUND_QUEUE = '1'
+      let originalTestInvocation: PsychicWorkersAppTestInvocationType
+
+      beforeEach(async () => {
+        const workersApp = PsychicAppWorkers.getOrFail()
+        originalTestInvocation = workersApp.testInvocation
+        workersApp.set('testInvocation', 'manual')
+
         background.connect()
+
+        for (const queue of background.queues) {
+          await queue.drain()
+          await queue.clean(5000, 10000, 'completed')
+        }
       })
 
       afterEach(() => {
-        process.env.REALLY_TEST_BACKGROUND_QUEUE = undefined
+        const workersApp = PsychicAppWorkers.getOrFail()
+        workersApp.set('testInvocation', originalTestInvocation)
       })
 
       it('adds the job to the queue corresponding to the workstream name with the workstream name as the group ID, and moves the priority into the group object', async () => {
@@ -144,13 +171,19 @@ describe('a backgrounded model', () => {
     })
 
     context('priority and named workstream', () => {
-      beforeEach(() => {
-        process.env.REALLY_TEST_BACKGROUND_QUEUE = '1'
-        background.connect()
+      let originalTestInvocation: PsychicWorkersAppTestInvocationType
+
+      beforeEach(async () => {
+        const workersApp = PsychicAppWorkers.getOrFail()
+        originalTestInvocation = workersApp.testInvocation
+        workersApp.set('testInvocation', 'manual')
+
+        await WorkerTestUtils.clean()
       })
 
       afterEach(() => {
-        process.env.REALLY_TEST_BACKGROUND_QUEUE = undefined
+        const workersApp = PsychicAppWorkers.getOrFail()
+        workersApp.set('testInvocation', originalTestInvocation)
       })
 
       it('adds the job to the queue corresponding to the workstream name with the workstream name as the group ID, and moves the priority into the group object', async () => {

--- a/spec/unit/setup/hooks.ts
+++ b/spec/unit/setup/hooks.ts
@@ -1,6 +1,8 @@
 import { DreamApp } from '@rvoh/dream'
 import { provideDreamViteMatchers, truncate } from '@rvoh/dream-spec-helpers'
 import initializePsychicApp from '../../../test-app/src/cli/helpers/initializePsychicApp.js'
+import { background } from '../../../src/index.js'
+import rmTmpFile from '../../helpers/rmTmpFile.js'
 
 provideDreamViteMatchers()
 
@@ -20,6 +22,14 @@ beforeEach(async () => {
   } catch (error) {
     console.error(error)
     throw error
+  }
+
+  background.connect()
+
+  try {
+    await rmTmpFile()
+  } catch {
+    // noop
   }
 
   await truncate(DreamApp)

--- a/spec/unit/test-utils/WorkerTestUtils/work.spec.ts
+++ b/spec/unit/test-utils/WorkerTestUtils/work.spec.ts
@@ -1,0 +1,80 @@
+import { Job } from 'bullmq'
+import PsychicAppWorkers, {
+  PsychicWorkersAppTestInvocationType,
+} from '../../../../src/psychic-app-workers/index.js'
+import WorkerTestUtils from '../../../../src/test-utils/WorkerTestUtils.js'
+import User from '../../../../test-app/src/app/models/User.js'
+import DummyService from '../../../../test-app/src/app/services/DummyService.js'
+import LastDummyServiceInNamedWorkstream from '../../../../test-app/src/app/services/LastDummyServiceInNamedWorkstream.js'
+import UrgentDummyService from '../../../../test-app/src/app/services/UrgentDummyService.js'
+
+describe('.work', () => {
+  let originalTestInvocation: PsychicWorkersAppTestInvocationType
+
+  beforeEach(async () => {
+    const workersApp = PsychicAppWorkers.getOrFail()
+    originalTestInvocation = workersApp.testInvocation
+    workersApp.set('testInvocation', 'manual')
+    await WorkerTestUtils.clean()
+  })
+
+  afterEach(() => {
+    const workersApp = PsychicAppWorkers.getOrFail()
+    workersApp.set('testInvocation', originalTestInvocation)
+  })
+
+  context('with no jobs', () => {
+    it('does nothing, but does not stall', async () => {
+      const serviceSpy = vi.spyOn(DummyService, 'classRunInBG').mockImplementation(async () => {})
+      const modelSpy = vi.spyOn(User, 'classRunInBG').mockImplementation(async () => {})
+
+      await WorkerTestUtils.work()
+
+      expect(serviceSpy).not.toHaveBeenCalled()
+      expect(modelSpy).not.toHaveBeenCalled()
+    }, 5000)
+  })
+
+  context('with existing jobs', () => {
+    it('works off all jobs in all queues', async () => {
+      const bgSpy = vi.spyOn(DummyService, 'classRunInBG').mockImplementation(async () => {})
+      const userSpy = vi.spyOn(User, 'classRunInBG').mockImplementation(async () => {})
+      const urgentSpy = vi.spyOn(UrgentDummyService, 'classRunInBG').mockImplementation(async () => {})
+      const workstreamSpy = vi
+        .spyOn(LastDummyServiceInNamedWorkstream, 'classRunInBG')
+        .mockImplementation(async () => {})
+
+      await DummyService.background('classRunInBG', 'message 1')
+      await DummyService.background('classRunInBG', 'message 2')
+      await User.background('classRunInBG', 'message 3')
+      await UrgentDummyService.background('classRunInBG', 'message 4')
+      await LastDummyServiceInNamedWorkstream.background('classRunInBG', 'message 5')
+
+      expect(bgSpy).not.toHaveBeenCalled()
+      expect(userSpy).not.toHaveBeenCalled()
+      expect(urgentSpy).not.toHaveBeenCalled()
+      expect(workstreamSpy).not.toHaveBeenCalled()
+
+      await WorkerTestUtils.work()
+      expect(bgSpy).toHaveBeenCalledWith('message 1', expect.any(Job))
+      expect(bgSpy).toHaveBeenCalledWith('message 2', expect.any(Job))
+      expect(userSpy).toHaveBeenCalledWith('message 3', expect.any(Job))
+      expect(urgentSpy).toHaveBeenCalledWith('message 4', expect.any(Job))
+      expect(workstreamSpy).toHaveBeenCalledWith('message 5', expect.any(Job))
+    })
+  })
+
+  context('when provided a queue', () => {
+    it('only works of the jobs from that queue', async () => {
+      const bgSpy = vi.spyOn(DummyService, 'classRunInBG').mockImplementation(async () => {})
+      await DummyService.background('classRunInBG', 'message 1')
+      expect(bgSpy).not.toHaveBeenCalled()
+
+      await WorkerTestUtils.work({ queue: 'snazzy' })
+      expect(bgSpy).not.toHaveBeenCalled()
+
+      await WorkerTestUtils.work({ queue: 'TestappBackgroundJobQueue' })
+      expect(bgSpy).toHaveBeenCalledWith('message 1', expect.any(Job))
+    })
+  })
+})

--- a/spec/unit/test-utils/WorkerTestUtils/workScheduled.spec.ts
+++ b/spec/unit/test-utils/WorkerTestUtils/workScheduled.spec.ts
@@ -1,0 +1,107 @@
+import { Job } from 'bullmq'
+import PsychicAppWorkers, {
+  PsychicWorkersAppTestInvocationType,
+} from '../../../../src/psychic-app-workers/index.js'
+import WorkerTestUtils from '../../../../src/test-utils/WorkerTestUtils.js'
+import User from '../../../../test-app/src/app/models/User.js'
+import DummyScheduledService from '../../../../test-app/src/app/services/DummyScheduledService.js'
+import DummyService from '../../../../test-app/src/app/services/DummyService.js'
+import LastDummyServiceInNamedWorkstream from '../../../../test-app/src/app/services/LastDummyServiceInNamedWorkstream.js'
+import UrgentDummyService from '../../../../test-app/src/app/services/UrgentDummyService.js'
+import parallelTestSafeQueueName from '../../../../src/background/helpers/parallelTestSafeQueueName.js'
+
+describe('.work', () => {
+  let originalTestInvocation: PsychicWorkersAppTestInvocationType
+
+  beforeEach(async () => {
+    const workersApp = PsychicAppWorkers.getOrFail()
+    originalTestInvocation = workersApp.testInvocation
+    workersApp.set('testInvocation', 'manual')
+    await WorkerTestUtils.clean()
+  })
+
+  afterEach(() => {
+    const workersApp = PsychicAppWorkers.getOrFail()
+    workersApp.set('testInvocation', originalTestInvocation)
+  })
+
+  context('with no scheduled jobs', () => {
+    it('does not call any scheduled methods, nor any other queued jobs, but also does not stall', async () => {
+      const serviceSpy = vi.spyOn(DummyService, 'classRunInBG').mockImplementation(async () => {})
+      const modelSpy = vi.spyOn(User, 'classRunInBG').mockImplementation(async () => {})
+      const scheduledSpy = vi.spyOn(DummyScheduledService, 'classRunInBg').mockResolvedValue(undefined)
+
+      // intentionally create queueable jobs to ensure that they do not get run
+      await DummyService.background('classRunInBG', 'message 2')
+      await User.background('classRunInBG', 'message 3')
+
+      await WorkerTestUtils.workScheduled()
+
+      expect(scheduledSpy).not.toHaveBeenCalled()
+      expect(serviceSpy).not.toHaveBeenCalled()
+      expect(modelSpy).not.toHaveBeenCalled()
+    }, 5000)
+  })
+
+  context('with existing scheduled jobs', () => {
+    it('works off all scheduled jobs', async () => {
+      const bgSpy = vi.spyOn(DummyService, 'classRunInBG').mockImplementation(async () => {})
+      const userSpy = vi.spyOn(User, 'classRunInBG').mockImplementation(async () => {})
+      const urgentSpy = vi.spyOn(UrgentDummyService, 'classRunInBG').mockImplementation(async () => {})
+      const workstreamSpy = vi
+        .spyOn(LastDummyServiceInNamedWorkstream, 'classRunInBG')
+        .mockImplementation(async () => {})
+      const scheduledSpy = vi.spyOn(DummyScheduledService, 'classRunInBg').mockResolvedValue(undefined)
+
+      await DummyService.background('classRunInBG', 'message 1')
+      await DummyService.background('classRunInBG', 'message 2')
+      await User.background('classRunInBG', 'message 3')
+      await UrgentDummyService.background('classRunInBG', 'message 4')
+      await LastDummyServiceInNamedWorkstream.background('classRunInBG', 'message 5')
+      await DummyScheduledService.schedule('0 * * * *', 'classRunInBg', 'message 6')
+
+      expect(bgSpy).not.toHaveBeenCalled()
+      expect(userSpy).not.toHaveBeenCalled()
+      expect(urgentSpy).not.toHaveBeenCalled()
+      expect(workstreamSpy).not.toHaveBeenCalled()
+      expect(scheduledSpy).not.toHaveBeenCalled()
+
+      await WorkerTestUtils.workScheduled()
+
+      expect(scheduledSpy).toHaveBeenCalledWith('message 6', expect.any(Job))
+
+      expect(bgSpy).not.toHaveBeenCalled()
+      expect(userSpy).not.toHaveBeenCalled()
+      expect(urgentSpy).not.toHaveBeenCalled()
+      expect(workstreamSpy).not.toHaveBeenCalled()
+    })
+
+    context('when provided a queue', () => {
+      it('only works of the jobs from that queue', async () => {
+        const scheduledSpy = vi.spyOn(DummyScheduledService, 'classRunInBg').mockResolvedValue(undefined)
+        await DummyScheduledService.schedule('0 * * * *', 'classRunInBg', 'message 1')
+        expect(scheduledSpy).not.toHaveBeenCalled()
+
+        await WorkerTestUtils.workScheduled({ queue: parallelTestSafeQueueName('snazzy') })
+        expect(scheduledSpy).not.toHaveBeenCalled()
+
+        await WorkerTestUtils.workScheduled({ queue: parallelTestSafeQueueName('TestappBackgroundJobQueue') })
+        expect(scheduledSpy).toHaveBeenCalledWith('message 1', expect.any(Job))
+      })
+    })
+
+    context('when provided a for', () => {
+      it('only works of the jobs from that queue', async () => {
+        const scheduledSpy = vi.spyOn(DummyScheduledService, 'classRunInBg').mockResolvedValue(undefined)
+        await DummyScheduledService.schedule('0 * * * *', 'classRunInBg', 'message 1')
+        expect(scheduledSpy).not.toHaveBeenCalled()
+
+        await WorkerTestUtils.workScheduled({ for: User })
+        expect(scheduledSpy).not.toHaveBeenCalled()
+
+        await WorkerTestUtils.workScheduled({ for: DummyScheduledService })
+        expect(scheduledSpy).toHaveBeenCalledWith('message 1', expect.any(Job))
+      })
+    })
+  })
+})

--- a/spec/unit/vite.config.ts
+++ b/spec/unit/vite.config.ts
@@ -1,3 +1,5 @@
+import '../../test-app/src/conf/loadEnv.js'
+
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -5,9 +7,9 @@ export default defineConfig({
     dir: './spec/unit',
     globals: true,
     setupFiles: ['luxon-jest-matchers', './spec/unit/setup/hooks.ts'],
-    fileParallelism: false,
-    maxConcurrency: 1,
-    maxWorkers: 1,
+    fileParallelism: true,
+    maxConcurrency: parseInt(process.env.DREAM_PARALLEL_TESTS || '1'),
+    maxWorkers: parseInt(process.env.DREAM_PARALLEL_TESTS || '1'),
     minWorkers: 1,
     mockReset: true,
     watch: false,

--- a/src/background/BaseBackgroundedService.ts
+++ b/src/background/BaseBackgroundedService.ts
@@ -1,9 +1,9 @@
 import { GlobalNameNotSet } from '@rvoh/dream'
 import { Job } from 'bullmq'
+import durationToSeconds from '../helpers/durationToSeconds.js'
 import { BackgroundJobConfig, DelayedJobOpts } from '../types/background.js'
 import { FunctionPropertyNames } from '../types/utils.js'
 import background from './index.js'
-import durationToSeconds from '../helpers/durationToSeconds.js'
 
 export default class BaseBackgroundedService {
   /**

--- a/src/background/helpers/nameToRedisQueueName.ts
+++ b/src/background/helpers/nameToRedisQueueName.ts
@@ -1,7 +1,9 @@
-import { Redis, Cluster } from 'ioredis'
+import { Cluster, Redis } from 'ioredis'
+import parallelTestSafeQueueName from './parallelTestSafeQueueName.js'
 
 export default function nameToRedisQueueName(queueName: string, redis: Redis | Cluster): string {
   queueName = queueName.replace(/\{|\}/g, '')
+
   if (redis instanceof Cluster) return `{${queueName}}`
-  return queueName
+  return parallelTestSafeQueueName(queueName)
 }

--- a/src/background/helpers/parallelTestSafeQueueName.ts
+++ b/src/background/helpers/parallelTestSafeQueueName.ts
@@ -1,0 +1,9 @@
+import EnvInternal from '../../helpers/EnvInternal.js'
+
+export default function parallelTestSafeQueueName(queueName: string) {
+  if (EnvInternal.isTest && (EnvInternal.integer('VITEST_POOL_ID', { optional: true }) || 0) > 1) {
+    queueName = `${queueName}-${EnvInternal.integer('VITEST_POOL_ID')}`
+  }
+
+  return queueName
+}

--- a/src/helpers/EnvInternal.ts
+++ b/src/helpers/EnvInternal.ts
@@ -2,7 +2,7 @@ import { Env } from '@rvoh/dream'
 
 const EnvInternal = new Env<{
   string: 'NODE_ENV' | 'PSYCHIC_CORE_DEVELOPMENT'
-  // integer: 'PORT'
+  integer: 'VITEST_POOL_ID'
   boolean: 'REALLY_TEST_BACKGROUND_QUEUE'
 }>()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,5 @@ export {
 
 export { default as NoQueueForSpecifiedQueueName } from './error/background/NoQueueForSpecifiedQueueName.js'
 export { default as NoQueueForSpecifiedWorkstream } from './error/background/NoQueueForSpecifiedWorkstream.js'
+
+export { default as WorkerTestUtils } from './test-utils/WorkerTestUtils.js'

--- a/src/test-utils/WorkerTestUtils.ts
+++ b/src/test-utils/WorkerTestUtils.ts
@@ -1,0 +1,150 @@
+import { Job, Queue, WorkerOptions } from 'bullmq'
+import background, { Background } from '../background/index.js'
+import { BackgroundJobData } from '../types/background.js'
+import parallelTestSafeQueueName from '../background/helpers/parallelTestSafeQueueName.js'
+
+const LOCK_TOKEN = 'psychic-test-worker'
+
+export default class WorkerTestUtils {
+  /*
+   * Safely encapsulate's a queue name in parallel test runs,
+   * capturing the VITEST_POOL_ID and appending it to the
+   * end of the queue name if VITEST_POOL_ID > 1
+   */
+  public static parallelTestSafeQueueName(queueName: string) {
+    return parallelTestSafeQueueName(queueName)
+  }
+
+  /*
+   * Works off all of the jobs in all queues. The jobs
+   * are worked off in a round-robin fashion until every queue
+   * is empty, at which point the promise will resolve
+   *
+   * ```ts
+   * await MyService.background('someMethod', ...)
+   * await WorkerTestUtils.work()
+   * // now you can safely assert the results of your background job
+   * ```
+   *
+   * NOTE: this is only useful if you are running with `testInvocation=manual`.
+   * make sure to set this in your workers config, or else in your test,
+   * so that jobs are successfully commited to the queue and can be worked off.
+   */
+  public static async work(opts: TestWorkerWorkOffOpts = {}) {
+    background.connect()
+    const queues = background.queues
+
+    let workWasDone: boolean = true
+
+    do {
+      workWasDone = false
+      for (const queue of queues) {
+        if (opts.queue && !this.queueNamesMatch(queue, opts.queue)) continue
+        workWasDone ||= await this.workOne(queue)
+      }
+    } while (workWasDone)
+  }
+
+  public static async workScheduled(opts: TestWorkerScheduledWorkOffOpts = {}) {
+    background.connect()
+
+    const queues = opts.queue
+      ? background.queues.filter(queue => queue.name === opts.queue)
+      : background.queues
+
+    if (opts.queue && !queues.length)
+      throw new Error(
+        `Expected to find queue with name: ${opts.queue}, but none were found by that name. The queue names available are: ${background.queues.map(queue => queue.name).join(', ')}`,
+      )
+
+    for (const queue of queues) {
+      const jobs = (await queue.getDelayed()) as Job[]
+      for (const job of jobs) {
+        const data = job.data as BackgroundJobData
+        if (opts.for) {
+          if (data.globalName === opts.for.globalName) {
+            await background.doWork(job)
+          }
+        } else {
+          await background.doWork(job)
+        }
+      }
+    }
+  }
+
+  /*
+   * iterates through each registered queue, and cleans out all
+   * jobs, including completed, failed, and scheduled jobs. This
+   * is especially useful before a test where you plan to exercise
+   * background jobs manually.
+   *
+   * If your entire app is continuously exercising background jobs
+   * manually, you may want to do this in your spec/setup/hooks.ts file,
+   * so that it can be called before every test.
+   *
+   * ```ts
+   * beforeEach(async () => {
+   *   await WorkerTestUtils.clean()
+   * })
+   * ```
+   */
+  public static async clean() {
+    background.connect()
+
+    for (const queue of background.queues) {
+      // clears all non-scheduled, non-completed, and non-failed jobs
+      await queue.drain()
+
+      // clear out completed and failed jobs
+      await queue.clean(0, 10000, 'completed')
+      await queue.clean(0, 10000, 'failed')
+
+      // clear out scheduled jobs
+      const schedulers = await queue.getJobSchedulers()
+      for (const scheduler of schedulers) {
+        await queue.removeJobScheduler(scheduler.key)
+      }
+    }
+  }
+
+  private static async workOne(queue: Queue): Promise<boolean> {
+    const worker = new Background.Worker(queue.name, async job => await background.doWork(job), {
+      autorun: false,
+      connection: queue.client,
+      concurrency: 1,
+    } as WorkerOptions)
+
+    if (!worker) throw new Error(`Failed to find worker for queue: ${queue.name}`)
+
+    const job = await worker.getNextJob(LOCK_TOKEN)
+    if (!job) return false
+
+    await this.processJob(job)
+    return true
+  }
+
+  private static queueNamesMatch(queue: Queue, compareQueueName: string): boolean {
+    return (
+      queue.name === parallelTestSafeQueueName(compareQueueName) ||
+      queue.name === `{${parallelTestSafeQueueName(compareQueueName)}`
+    )
+  }
+
+  private static async processJob(job: Job) {
+    try {
+      const res = await background.doWork(job)
+      await job.moveToCompleted(res, LOCK_TOKEN, false)
+    } catch (err) {
+      await job.moveToFailed(err as Error, LOCK_TOKEN, false)
+    }
+  }
+}
+
+interface TestWorkerWorkOffOpts {
+  queue?: string
+}
+
+interface TestWorkerScheduledWorkOffOpts {
+  queue?: string
+  for?: { globalName: string }
+}

--- a/src/types/background.ts
+++ b/src/types/background.ts
@@ -79,7 +79,7 @@ export interface QueueBackgroundJobConfig<
   T extends BaseScheduledService | BaseBackgroundedService,
   PsyTypes extends T['psychicTypes'] = T['psychicTypes'],
   QueueGroupMap = PsyTypes['queueGroupMap'],
-  Queue extends keyof QueueGroupMap = keyof QueueGroupMap,
+  Queue extends keyof QueueGroupMap & string = keyof QueueGroupMap & string,
   Groups extends QueueGroupMap[Queue] = QueueGroupMap[Queue],
   GroupId = Groups[number & keyof Groups],
 > extends BaseBackgroundJobConfig {

--- a/test-app/src/app/models/User.ts
+++ b/test-app/src/app/models/User.ts
@@ -6,11 +6,11 @@ import { BackgroundJobConfig, PsychicAppWorkers } from '../../../../src/index.js
 import ApplicationBackgroundedModel from './ApplicationBackgroundedModel.js'
 
 export default class User extends ApplicationBackgroundedModel {
-  public get table() {
+  public override get table() {
     return 'users' as const
   }
 
-  public static get backgroundJobConfig(): BackgroundJobConfig<ApplicationBackgroundedModel> {
+  public static override get backgroundJobConfig(): BackgroundJobConfig<ApplicationBackgroundedModel> {
     return { priority: 'urgent', workstream: 'snazzy' }
   }
 

--- a/test-app/src/app/services/ApplicationBackgroundedService.ts
+++ b/test-app/src/app/services/ApplicationBackgroundedService.ts
@@ -2,7 +2,7 @@ import { BaseBackgroundedService } from '../../../../src/index.js'
 import psychicTypes from '../../types/psychic.js'
 
 export default class ApplicationBackgroundedService extends BaseBackgroundedService {
-  public get psychicTypes() {
+  public override get psychicTypes() {
     return psychicTypes
   }
 }

--- a/test-app/src/app/services/ApplicationScheduledService.ts
+++ b/test-app/src/app/services/ApplicationScheduledService.ts
@@ -2,7 +2,7 @@ import BaseScheduledService from '../../../../src/background/BaseScheduledServic
 import psychicTypes from '../../types/psychic.js'
 
 export default class ApplicationScheduledService extends BaseScheduledService {
-  public get psychicTypes() {
+  public override get psychicTypes() {
     return psychicTypes
   }
 

--- a/test-app/src/app/services/LastDummyService.ts
+++ b/test-app/src/app/services/LastDummyService.ts
@@ -4,7 +4,7 @@ import { BackgroundJobConfig, PsychicAppWorkers } from '../../../../src/index.js
 import ApplicationBackgroundedService from './ApplicationBackgroundedService.js'
 
 export default class LastDummyService extends ApplicationBackgroundedService {
-  public static get backgroundJobConfig(): BackgroundJobConfig<ApplicationBackgroundedService> {
+  public static override get backgroundJobConfig(): BackgroundJobConfig<ApplicationBackgroundedService> {
     return { priority: 'last' }
   }
 

--- a/test-app/src/conf/dream.ts
+++ b/test-app/src/conf/dream.ts
@@ -8,6 +8,8 @@ export default async function configureDream(app: DreamApp) {
   app.set('primaryKeyType', 'bigserial')
   app.set('inflections', inflections)
 
+  app.set('parallelTests', Number(process.env.DREAM_PARALLEL_TESTS || '0'))
+
   await app.load('models', srcPath('app', 'models'), path => importDefault(path))
   await app.load('serializers', srcPath('app', 'serializers'), path => importAll(path))
 

--- a/test-app/src/conf/workers.ts
+++ b/test-app/src/conf/workers.ts
@@ -80,18 +80,15 @@ export default (workersApp: PsychicAppWorkers) => {
       enableOfflineQueue: false,
     }),
 
-    defaultWorkerConnection:
-      process.env.NOT_REAL_FLAG === '1'
-        ? undefined
-        : new Redis({
-            username: process.env.REDIS_USER!,
-            password: process.env.REDIS_PASSWORD!,
-            host: process.env.REDIS_HOST!,
-            port: process.env.REDIS_PORT ? Number(process.env.REDIS_PORT) : 6379,
-            // uncomment if you need tls
-            // tls: {},
-            maxRetriesPerRequest: null,
-          }),
+    defaultWorkerConnection: new Redis({
+      username: process.env.REDIS_USER!,
+      password: process.env.REDIS_PASSWORD!,
+      host: process.env.REDIS_HOST!,
+      port: process.env.REDIS_PORT ? Number(process.env.REDIS_PORT) : 6379,
+      // uncomment if you need tls
+      // tls: {},
+      maxRetriesPerRequest: null,
+    }),
 
     // To set up a simple cluster on a dev machine for testing:
     //   https://medium.com/@bertrandoubida/setting-up-redis-cluster-on-macos-cf35a21465a

--- a/yarn.lock
+++ b/yarn.lock
@@ -576,6 +576,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/hashes@npm:^1.1.5":
+  version: 1.8.0
+  resolution: "@noble/hashes@npm:1.8.0"
+  checksum: 10c0/06a0b52c81a6fa7f04d67762e08b2c476a00285858150caeaaff4037356dd5e119f45b2a530f638b77a5eeca013168ec1b655db41bae3236cb2e9d511484fc77
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -625,6 +632,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@paralleldrive/cuid2@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@paralleldrive/cuid2@npm:2.2.2"
+  dependencies:
+    "@noble/hashes": "npm:^1.1.5"
+  checksum: 10c0/af5826df93de437121308f4f4ce0b2eeb89b60bb57a1a6592fb89c0d40d311ad1d9f3f6a4db2cce6f2bcf572de1aa3f85704254e89b18ce61c41ebb06564c4ee
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -632,135 +648,142 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.35.0"
+"@rollup/rollup-android-arm-eabi@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.41.0"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm64@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-android-arm64@npm:4.35.0"
+"@rollup/rollup-android-arm64@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-android-arm64@npm:4.41.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.35.0"
+"@rollup/rollup-darwin-arm64@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.41.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-x64@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-darwin-x64@npm:4.35.0"
+"@rollup/rollup-darwin-x64@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-darwin-x64@npm:4.41.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-arm64@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.35.0"
+"@rollup/rollup-freebsd-arm64@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.41.0"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-x64@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.35.0"
+"@rollup/rollup-freebsd-x64@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.41.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.35.0"
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.41.0"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-musleabihf@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.35.0"
+"@rollup/rollup-linux-arm-musleabihf@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.41.0"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-gnu@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.35.0"
+"@rollup/rollup-linux-arm64-gnu@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.41.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.35.0"
+"@rollup/rollup-linux-arm64-musl@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.41.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-loongarch64-gnu@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.35.0"
+"@rollup/rollup-linux-loongarch64-gnu@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.41.0"
   conditions: os=linux & cpu=loong64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-powerpc64le-gnu@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.35.0"
+"@rollup/rollup-linux-powerpc64le-gnu@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.41.0"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-gnu@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.35.0"
+"@rollup/rollup-linux-riscv64-gnu@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.41.0"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-s390x-gnu@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.35.0"
+"@rollup/rollup-linux-riscv64-musl@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.41.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.41.0"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.35.0"
+"@rollup/rollup-linux-x64-gnu@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.41.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-musl@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.35.0"
+"@rollup/rollup-linux-x64-musl@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.41.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.35.0"
+"@rollup/rollup-win32-arm64-msvc@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.41.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.35.0"
+"@rollup/rollup-win32-ia32-msvc@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.41.0"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-msvc@npm:4.35.0":
-  version: 4.35.0
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.35.0"
+"@rollup/rollup-win32-x64-msvc@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.41.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -821,7 +844,7 @@ __metadata:
     "@eslint/js": "npm:=9.0.0"
     "@rvoh/dream": "npm:^0.39.0"
     "@rvoh/dream-spec-helpers": "npm:^0.2.4"
-    "@rvoh/psychic": "npm:^0.31.0"
+    "@rvoh/psychic": "npm:^0.35.1"
     "@rvoh/psychic-spec-helpers": "npm:^0.6.0"
     "@socket.io/redis-adapter": "npm:^8.3.0"
     "@socket.io/redis-emitter": "npm:^5.1.0"
@@ -846,7 +869,7 @@ __metadata:
     typedoc: "npm:^0.26.6"
     typescript: "npm:^5.8.2"
     typescript-eslint: "npm:=7.18.0"
-    vitest: "npm:^3.1.1"
+    vitest: "npm:^3.1.3"
   peerDependencies:
     "@rvoh/dream": "*"
     "@rvoh/psychic": "*"
@@ -855,9 +878,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rvoh/psychic@npm:^0.31.0":
-  version: 0.31.0
-  resolution: "@rvoh/psychic@npm:0.31.0"
+"@rvoh/psychic@npm:^0.35.1":
+  version: 0.35.1
+  resolution: "@rvoh/psychic@npm:0.35.1"
   dependencies:
     "@types/cookie-parser": "npm:^1.4.8"
     "@types/cors": "npm:^2.8.17"
@@ -874,7 +897,7 @@ __metadata:
     "@types/express": "*"
     commander: "*"
     express: "*"
-  checksum: 10c0/24929c3c3c628c21989eefce6f166402af3045adffc857a8c30449cf165e0b7350074e17d0f1bbe5e8382eaf518076f044fdcb242ab81f185279f7611c692feb
+  checksum: 10c0/e23d434b58888b29998bb96d368a7b84d01bf453b244aaebbe46fa818cc4c802c4846195fd8f5d6a3c04dd6766b8870e8c960cc6a50b0ff5100d80da160d98f6
   languageName: node
   linkType: hard
 
@@ -1023,7 +1046,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:1.0.6, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6":
+"@types/estree@npm:1.0.7":
+  version: 1.0.7
+  resolution: "@types/estree@npm:1.0.7"
+  checksum: 10c0/be815254316882f7c40847336cd484c3bc1c3e34f710d197160d455dc9d6d050ffbf4c3bc76585dba86f737f020ab20bdb137ebe0e9116b0c86c7c0342221b8c
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6":
   version: 1.0.6
   resolution: "@types/estree@npm:1.0.6"
   checksum: 10c0/cdfd751f6f9065442cd40957c07fd80361c962869aa853c1c2fd03e101af8b9389d8ff4955a43a6fcfa223dd387a089937f95be0f3eec21ca527039fd2d9859a
@@ -1342,23 +1372,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:3.1.1":
-  version: 3.1.1
-  resolution: "@vitest/expect@npm:3.1.1"
+"@vitest/expect@npm:3.1.3":
+  version: 3.1.3
+  resolution: "@vitest/expect@npm:3.1.3"
   dependencies:
-    "@vitest/spy": "npm:3.1.1"
-    "@vitest/utils": "npm:3.1.1"
+    "@vitest/spy": "npm:3.1.3"
+    "@vitest/utils": "npm:3.1.3"
     chai: "npm:^5.2.0"
     tinyrainbow: "npm:^2.0.0"
-  checksum: 10c0/ef4528d0ebb89eb3cc044cf597d051c35df8471bb6ba4029e9b3412aa69d0d85a0ce4eb49531fc78fe1ebd97e6428260463068cc96a8d8c1a80150dedfd1ab3a
+  checksum: 10c0/3a61e5526ed57491c9c230cb592849a2c15e6b4376bfaec4f623ac75fdcf5c24c322949cfb5362136fc8be5eb19be88d094917ea5f700bd3da0ea0c68ee4a8d9
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:3.1.1":
-  version: 3.1.1
-  resolution: "@vitest/mocker@npm:3.1.1"
+"@vitest/mocker@npm:3.1.3":
+  version: 3.1.3
+  resolution: "@vitest/mocker@npm:3.1.3"
   dependencies:
-    "@vitest/spy": "npm:3.1.1"
+    "@vitest/spy": "npm:3.1.3"
     estree-walker: "npm:^3.0.3"
     magic-string: "npm:^0.30.17"
   peerDependencies:
@@ -1369,57 +1399,57 @@ __metadata:
       optional: true
     vite:
       optional: true
-  checksum: 10c0/9264558809e2d7c77ae9ceefad521dc5f886a567aaf0bdd021b73089b8906ffd92c893f3998d16814f38fc653c7413836f508712355c87749a0e86c7d435eec1
+  checksum: 10c0/6e6a62e27aa6cd146d14ae64eb9acfc0f49e7479ca426af1fb4df362456aa3456abf29731247659032e4bfb7ac9482fca1d1c7e1501e1a186eb211221e1f613a
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:3.1.1, @vitest/pretty-format@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "@vitest/pretty-format@npm:3.1.1"
+"@vitest/pretty-format@npm:3.1.3, @vitest/pretty-format@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "@vitest/pretty-format@npm:3.1.3"
   dependencies:
     tinyrainbow: "npm:^2.0.0"
-  checksum: 10c0/540cd46d317fc80298c93b185f3fb48dfe90eaaa3942fd700fde6e88d658772c01b56ad5b9b36e4ac368a02e0fc8e0dc72bbdd6dd07a5d75e89ef99c8df5ba6e
+  checksum: 10c0/eba164d2c0b2babbcf6bb054da3b326d08cc3a0289ade3c64309bfe5e7c3124cd4d45a60b2f673cf4f5b3a97381fb7af7009780a5d9665afdf7f8263fa34c068
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:3.1.1":
-  version: 3.1.1
-  resolution: "@vitest/runner@npm:3.1.1"
+"@vitest/runner@npm:3.1.3":
+  version: 3.1.3
+  resolution: "@vitest/runner@npm:3.1.3"
   dependencies:
-    "@vitest/utils": "npm:3.1.1"
+    "@vitest/utils": "npm:3.1.3"
     pathe: "npm:^2.0.3"
-  checksum: 10c0/35a541069c3c94a2dd02fca2d70cc8d5e66ba2e891cfb80da354174f510aeb96774ffb34fff39cecde9d5c969be4dd20e240a900beb9b225b7512a615ecc5503
+  checksum: 10c0/f03c26e72657242ce68a93b46ee8a4e6fa1a290850be608988622a3efef744ffadc0436123acafe61977608b287b1637f4f781d27107ee0c33937c54f547159d
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:3.1.1":
-  version: 3.1.1
-  resolution: "@vitest/snapshot@npm:3.1.1"
+"@vitest/snapshot@npm:3.1.3":
+  version: 3.1.3
+  resolution: "@vitest/snapshot@npm:3.1.3"
   dependencies:
-    "@vitest/pretty-format": "npm:3.1.1"
+    "@vitest/pretty-format": "npm:3.1.3"
     magic-string: "npm:^0.30.17"
     pathe: "npm:^2.0.3"
-  checksum: 10c0/43e5fc5db580f20903eb1493d07f08752df8864f7b9b7293a202b2ffe93d8c196a5614d66dda096c6bacc16e12f1836f33ba41898812af6d32676d1eb501536a
+  checksum: 10c0/60b70c1d878c3d9a4fe3464d14be2318a7a3be24131beb801712735d5dcbc7db7b798f21c98c6fbad4998554992038b29655e1b6e2503242627f203fd89c97c3
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:3.1.1":
-  version: 3.1.1
-  resolution: "@vitest/spy@npm:3.1.1"
+"@vitest/spy@npm:3.1.3":
+  version: 3.1.3
+  resolution: "@vitest/spy@npm:3.1.3"
   dependencies:
     tinyspy: "npm:^3.0.2"
-  checksum: 10c0/896659d4b42776cfa2057a1da2c33adbd3f2ebd28005ca606d1616d08d2e726dc1460fb37f1ea7f734756b5bccf926c7165f410e63f0a3b8d992eb5489528b08
+  checksum: 10c0/6a8c187069827c56f3492f212ccf76c797fe52392849948af736a0f579e4533fa91041d829e2574b252af4aaadec066ca0714450d6457b31526153978bc55192
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:3.1.1":
-  version: 3.1.1
-  resolution: "@vitest/utils@npm:3.1.1"
+"@vitest/utils@npm:3.1.3":
+  version: 3.1.3
+  resolution: "@vitest/utils@npm:3.1.3"
   dependencies:
-    "@vitest/pretty-format": "npm:3.1.1"
+    "@vitest/pretty-format": "npm:3.1.3"
     loupe: "npm:^3.1.3"
     tinyrainbow: "npm:^2.0.0"
-  checksum: 10c0/a9cfe0c0f095b58644ce3ba08309de5be8564c10dad9e62035bd378e60b2834e6a256e6e4ded7dcf027fdc2371301f7965040ad3e6323b747d5b3abbb7ceb0d6
+  checksum: 10c0/1c4ea711b87a8b2c7dc2da91f20427dccc34c0d1d0e81b8142780d24b6caa3c724e8287f7e01e9e875262b6bb912d55711fb99e66f718ba30cc21706a335829d
   languageName: node
   linkType: hard
 
@@ -2287,10 +2317,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "es-module-lexer@npm:1.6.0"
-  checksum: 10c0/667309454411c0b95c476025929881e71400d74a746ffa1ff4cb450bd87f8e33e8eef7854d68e401895039ac0bac64e7809acbebb6253e055dd49ea9e3ea9212
+"es-module-lexer@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "es-module-lexer@npm:1.7.0"
+  checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
   languageName: node
   linkType: hard
 
@@ -2628,7 +2658,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect-type@npm:^1.2.0":
+"expect-type@npm:^1.2.1":
   version: 1.2.1
   resolution: "expect-type@npm:1.2.1"
   checksum: 10c0/b775c9adab3c190dd0d398c722531726cdd6022849b4adba19dceab58dda7e000a7c6c872408cd73d665baa20d381eca36af4f7b393a4ba60dd10232d1fb8898
@@ -2761,6 +2791,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fdir@npm:^6.4.4":
+  version: 6.4.4
+  resolution: "fdir@npm:6.4.4"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 10c0/6ccc33be16945ee7bc841e1b4178c0b4cf18d3804894cb482aa514651c962a162f96da7ffc6ebfaf0df311689fb70091b04dd6caffe28d56b9ebdc0e7ccadfdd
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^8.0.0":
   version: 8.0.0
   resolution: "file-entry-cache@npm:8.0.0"
@@ -2843,13 +2885,13 @@ __metadata:
   linkType: hard
 
 "formidable@npm:^3.5.1":
-  version: 3.5.2
-  resolution: "formidable@npm:3.5.2"
+  version: 3.5.4
+  resolution: "formidable@npm:3.5.4"
   dependencies:
+    "@paralleldrive/cuid2": "npm:^2.2.2"
     dezalgo: "npm:^1.0.4"
-    hexoid: "npm:^2.0.0"
     once: "npm:^1.4.0"
-  checksum: 10c0/c26d89ba84d392f0e68ba1aca9f779e0f2e94db053d95df562c730782956f302e3f069c07ab96f991415af915ac7b8771f4c813d298df43577fdf439e1e8741e
+  checksum: 10c0/3a311ce57617eb8f532368e91c0f2bbfb299a0f1a35090e085bd6ca772298f196fbb0b66f0d4b5549d7bf3c5e1844439338d4402b7b6d1fedbe206ad44a931f8
   languageName: node
   linkType: hard
 
@@ -3104,13 +3146,6 @@ __metadata:
   dependencies:
     "@types/hast": "npm:^3.0.0"
   checksum: 10c0/b898bc9fe27884b272580d15260b6bbdabe239973a147e97fa98c45fa0ffec967a481aaa42291ec34fb56530dc2d484d473d7e2bae79f39c83f3762307edfea8
-  languageName: node
-  linkType: hard
-
-"hexoid@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "hexoid@npm:2.0.0"
-  checksum: 10c0/a9d5e6f4adeaefcb4a53803dd48bf0a242d92e8ec699555aea616c4bf8f91788f03093595085976f63d6830815dd080c063503540fabc7e854ebfb11161687c6
   languageName: node
   linkType: hard
 
@@ -4353,6 +4388,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "picomatch@npm:4.0.2"
+  checksum: 10c0/7c51f3ad2bb42c776f49ebf964c644958158be30d0a510efd5a395e8d49cb5acfed5b82c0c5b365523ce18e6ab85013c9ebe574f60305892ec3fa8eee8304ccc
+  languageName: node
+  linkType: hard
+
 "pluralize-esm@npm:^9.0.5":
   version: 9.0.5
   resolution: "pluralize-esm@npm:9.0.5"
@@ -4698,30 +4740,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^4.30.1":
-  version: 4.35.0
-  resolution: "rollup@npm:4.35.0"
+"rollup@npm:^4.34.9":
+  version: 4.41.0
+  resolution: "rollup@npm:4.41.0"
   dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.35.0"
-    "@rollup/rollup-android-arm64": "npm:4.35.0"
-    "@rollup/rollup-darwin-arm64": "npm:4.35.0"
-    "@rollup/rollup-darwin-x64": "npm:4.35.0"
-    "@rollup/rollup-freebsd-arm64": "npm:4.35.0"
-    "@rollup/rollup-freebsd-x64": "npm:4.35.0"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.35.0"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.35.0"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.35.0"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.35.0"
-    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.35.0"
-    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.35.0"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.35.0"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.35.0"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.35.0"
-    "@rollup/rollup-linux-x64-musl": "npm:4.35.0"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.35.0"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.35.0"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.35.0"
-    "@types/estree": "npm:1.0.6"
+    "@rollup/rollup-android-arm-eabi": "npm:4.41.0"
+    "@rollup/rollup-android-arm64": "npm:4.41.0"
+    "@rollup/rollup-darwin-arm64": "npm:4.41.0"
+    "@rollup/rollup-darwin-x64": "npm:4.41.0"
+    "@rollup/rollup-freebsd-arm64": "npm:4.41.0"
+    "@rollup/rollup-freebsd-x64": "npm:4.41.0"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.41.0"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.41.0"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.41.0"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.41.0"
+    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.41.0"
+    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.41.0"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.41.0"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.41.0"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.41.0"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.41.0"
+    "@rollup/rollup-linux-x64-musl": "npm:4.41.0"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.41.0"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.41.0"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.41.0"
+    "@types/estree": "npm:1.0.7"
     fsevents: "npm:~2.3.2"
   dependenciesMeta:
     "@rollup/rollup-android-arm-eabi":
@@ -4750,6 +4793,8 @@ __metadata:
       optional: true
     "@rollup/rollup-linux-riscv64-gnu":
       optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
     "@rollup/rollup-linux-s390x-gnu":
       optional: true
     "@rollup/rollup-linux-x64-gnu":
@@ -4766,7 +4811,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 10c0/5a04add5a48173b1d95deb5422a96833b7df91b14ccec462c048be48241a79ecee2c1b843511b91ca8b6124bdbae134ccfebe80d4222a93e98e73795d161d3cc
+  checksum: 10c0/4c3d361f400317cb18f5e3912553a514bb1dcc7ce0c92ff66b9786b598632eb1d56f7bb1cc11ed16a4ccdbe6808ae851bc6bde5d2305cc587450c6212e69617f
   languageName: node
   linkType: hard
 
@@ -5091,10 +5136,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"std-env@npm:^3.8.1":
-  version: 3.8.1
-  resolution: "std-env@npm:3.8.1"
-  checksum: 10c0/e9b19cca6bc6f06f91607db5b636662914ca8ec9efc525a99da6ec7e493afec109d3b017d21d9782b4369fcfb2891c7c4b4e3c60d495fdadf6861ce434e07bf8
+"std-env@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "std-env@npm:3.9.0"
+  checksum: 10c0/4a6f9218aef3f41046c3c7ecf1f98df00b30a07f4f35c6d47b28329bc2531eef820828951c7d7b39a1c5eb19ad8a46e3ddfc7deb28f0a2f3ceebee11bab7ba50
   languageName: node
   linkType: hard
 
@@ -5248,6 +5293,16 @@ __metadata:
   version: 0.3.2
   resolution: "tinyexec@npm:0.3.2"
   checksum: 10c0/3efbf791a911be0bf0821eab37a3445c2ba07acc1522b1fa84ae1e55f10425076f1290f680286345ed919549ad67527d07281f1c19d584df3b74326909eb1f90
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.13":
+  version: 0.2.13
+  resolution: "tinyglobby@npm:0.2.13"
+  dependencies:
+    fdir: "npm:^6.4.4"
+    picomatch: "npm:^4.0.2"
+  checksum: 10c0/ef07dfaa7b26936601d3f6d999f7928a4d1c6234c5eb36896bb88681947c0d459b7ebe797022400e555fe4b894db06e922b95d0ce60cb05fd827a0a66326b18c
   languageName: node
   linkType: hard
 
@@ -5559,29 +5614,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-node@npm:3.1.1":
-  version: 3.1.1
-  resolution: "vite-node@npm:3.1.1"
+"vite-node@npm:3.1.3":
+  version: 3.1.3
+  resolution: "vite-node@npm:3.1.3"
   dependencies:
     cac: "npm:^6.7.14"
     debug: "npm:^4.4.0"
-    es-module-lexer: "npm:^1.6.0"
+    es-module-lexer: "npm:^1.7.0"
     pathe: "npm:^2.0.3"
     vite: "npm:^5.0.0 || ^6.0.0"
   bin:
     vite-node: vite-node.mjs
-  checksum: 10c0/15ee73c472ae00f042a7cee09a31355d2c0efbb2dab160377545be9ba4b980a5f4cb2841b98319d87bedf630bbbb075e6b40796b39f65610920cf3fde66fdf8d
+  checksum: 10c0/d69a1e52361bc0af22d1178db61674ef768cfd3c5610733794bb1e7a36af113da287dd89662a1ad57fd4f6c3360ca99678f5428ba837f239df4091d7891f2e4c
   languageName: node
   linkType: hard
 
 "vite@npm:^5.0.0 || ^6.0.0":
-  version: 6.2.6
-  resolution: "vite@npm:6.2.6"
+  version: 6.3.5
+  resolution: "vite@npm:6.3.5"
   dependencies:
     esbuild: "npm:^0.25.0"
+    fdir: "npm:^6.4.4"
     fsevents: "npm:~2.3.3"
+    picomatch: "npm:^4.0.2"
     postcss: "npm:^8.5.3"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
+    tinyglobby: "npm:^0.2.13"
   peerDependencies:
     "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
     jiti: ">=1.21.0"
@@ -5622,40 +5680,41 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/68a2ed3e61bdd654c59b817b4f3203065241c66d1739faa707499130f3007bc3a666c7a8320a4198e275e62b5e4d34d9b78a6533f69e321d366e76f5093b2071
+  checksum: 10c0/df70201659085133abffc6b88dcdb8a57ef35f742a01311fc56a4cfcda6a404202860729cc65a2c401a724f6e25f9ab40ce4339ed4946f550541531ced6fe41c
   languageName: node
   linkType: hard
 
-"vitest@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "vitest@npm:3.1.1"
+"vitest@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "vitest@npm:3.1.3"
   dependencies:
-    "@vitest/expect": "npm:3.1.1"
-    "@vitest/mocker": "npm:3.1.1"
-    "@vitest/pretty-format": "npm:^3.1.1"
-    "@vitest/runner": "npm:3.1.1"
-    "@vitest/snapshot": "npm:3.1.1"
-    "@vitest/spy": "npm:3.1.1"
-    "@vitest/utils": "npm:3.1.1"
+    "@vitest/expect": "npm:3.1.3"
+    "@vitest/mocker": "npm:3.1.3"
+    "@vitest/pretty-format": "npm:^3.1.3"
+    "@vitest/runner": "npm:3.1.3"
+    "@vitest/snapshot": "npm:3.1.3"
+    "@vitest/spy": "npm:3.1.3"
+    "@vitest/utils": "npm:3.1.3"
     chai: "npm:^5.2.0"
     debug: "npm:^4.4.0"
-    expect-type: "npm:^1.2.0"
+    expect-type: "npm:^1.2.1"
     magic-string: "npm:^0.30.17"
     pathe: "npm:^2.0.3"
-    std-env: "npm:^3.8.1"
+    std-env: "npm:^3.9.0"
     tinybench: "npm:^2.9.0"
     tinyexec: "npm:^0.3.2"
+    tinyglobby: "npm:^0.2.13"
     tinypool: "npm:^1.0.2"
     tinyrainbow: "npm:^2.0.0"
     vite: "npm:^5.0.0 || ^6.0.0"
-    vite-node: "npm:3.1.1"
+    vite-node: "npm:3.1.3"
     why-is-node-running: "npm:^2.3.0"
   peerDependencies:
     "@edge-runtime/vm": "*"
     "@types/debug": ^4.1.12
     "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
-    "@vitest/browser": 3.1.1
-    "@vitest/ui": 3.1.1
+    "@vitest/browser": 3.1.3
+    "@vitest/ui": 3.1.3
     happy-dom: "*"
     jsdom: "*"
   peerDependenciesMeta:
@@ -5675,7 +5734,7 @@ __metadata:
       optional: true
   bin:
     vitest: vitest.mjs
-  checksum: 10c0/680f31d2a7ca59509f837acdbacd9dff405e1b00c606d7cd29717127c6b543f186055854562c2604f74c5cd668b70174968d28feb4ed948a7e013c9477a68d50
+  checksum: 10c0/954b3579a2d925606df7f78e367ae64eab52c8c5ba2bb2fed94d335a06c910202a4ce080bb02d8148c8b4782488c6d229e963617be8d0c7da96a1c944dd291d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
By default, we will automatically invoke any method that gets pushed into the background in test environments, preventing the need for any redis connections in tests, nor any need to manually run things thin the queue to move your tests forward. However, if the developer decides they want to be able to utilize the queue in tests, this PR provides the ability to do so.

To activate the feature, you will first need to set the `testInvocation` to `manual` in your workers config.

```ts
workersApp.set('testInvocation', 'manual')
```

This can also be done on a test-by-test basis. In this case, you can simply add a hook to turn it on and then off again, only for a particular test, like so:

```ts
beforeEach(() => {
  PsychicAppWorkers.getOrFail().set('testInvocation', 'manual')
})

afterEach(() => {
  PsychicAppWorkers.getOrFail().set('testInvocation', 'automatic')
})
```

Once the feature is activated, you can utilize it during tests like so:

```ts
// to clean all jobs from all queues:
await WorkerTestUtils.clean()

// to manually run all jobs that have been pushed to any queue:
await WorkerTestUtils.work()

// to manually run all jobs that have been pushed to the `snazzy` queue
await WorkerTestUtils.work({ queue: 'snazzy' })

// to manually run all scheduled jobs:
await WorkerTestUtils.workScheduled()

// to manually run only scheduled jobs for a certain queue
await WorkerTestUtils.workScheduled({ queue: 'MyQueue' })

// to manually run only scheduled jobs for a certain class
await WorkerTestUtils.workScheduled({ for: MyScheduledService })
```