### PR TITLE
Security hardening: supply-chain install/CI defaults

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,6 +19,24 @@ permissions:
   statuses: none
 
 jobs:
+  check-cooldown-excludes:
+    name: Cooldown exclude allowlist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: minimumReleaseAgeExclude must be @rvoh/* only
+        run: |
+          # SECURITY: the minimumReleaseAge cooldown bypass list must stay @rvoh/*
+          # only (our own packages). Any third-party entry is a permanent
+          # supply-chain bypass and must be rejected — apply urgent patches via a
+          # transient, reverted override instead of a persistent exclude.
+          bad=$(grep -nE '^[[:space:]]*minimumReleaseAgeExclude' .npmrc | grep -vE '=[[:space:]]*@rvoh/' || true)
+          if [ -n "$bad" ]; then
+            echo "::error::Non-@rvoh minimumReleaseAgeExclude entries (cooldown bypass must stay @rvoh/* only):"
+            echo "$bad"
+            exit 1
+          fi
+
   uspec:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/.npmrc
+++ b/.npmrc
@@ -2,7 +2,7 @@ registry=https://registry.npmjs.org
 @rvoh:registry=https://registry.npmjs.org
 //registry.npmjs.org/:always-auth=true
 
-minimumReleaseAge=1440 # (in minutes, ensuring that all packages must be at least 24 hours old)
+minimumReleaseAge=4320 # 3 days, in minutes (supply-chain cooldown; kept under the CVE-patch SLA so routine patching needs no bypass)
 minimumReleaseAgeExclude[] = @rvoh/dream
 minimumReleaseAgeExclude[] = @rvoh/psychic
 minimumReleaseAgeExclude[] = @rvoh/dream-spec-helpers

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,3 +7,16 @@ We currently support the latest version of psychic-workers v2. Our goal is to av
 ## Reporting a Vulnerability
 
 To report a vulnerability, please contact us at [psychic-security@rvohealth.com](mailto:psychic-security@rvohealth.com). Once the vulnerability is verified, a patch will be provided. Once the patch is provided, a new version will be published closing the vulnerability. Private contact will resume between the reporter and the code maintainers until the vulnerability is resolved.
+
+## Supply-chain hardening
+
+This package is developed and published with defenses against install-time supply-chain attacks (the Shai-Hulud class of npm worm, which runs from a dependency's `postinstall` and/or publishes a compromised version for maintainers to install before it is noticed):
+
+- **Dependency build scripts are blocked by default.** pnpm 10+ does not run dependency lifecycle scripts; `pnpm-workspace.yaml` keeps a deliberately minimal `allowBuilds` allowlist (only the few packages that genuinely need to build). Every entry re-opens script execution, so additions require a clear reason.
+- **Release-age cooldown.** `.npmrc` sets `minimumReleaseAge=4320` (3 days), so freshly-published dependency versions — the window in which most worm-injected releases are caught and unpublished — are not installed. Three days stays under the critical-CVE patch SLA, so routine patching never needs a bypass.
+- **The cooldown exclude list is `@rvoh/*`-only, enforced in CI.** Only our own first-party packages are exempt from the cooldown. A CI check (`check-cooldown-excludes`) fails the build if any non-`@rvoh/*` entry is added to `minimumReleaseAgeExclude`, so a permanent third-party bypass cannot be introduced silently. Apply an urgent third-party patch with a transient, reverted override instead.
+- **Registry pinning.** `.npmrc` pins the npm registry so installs cannot be redirected to a malicious mirror.
+
+## Publishing posture
+
+Releases are published **manually, from a maintainer's machine, gated by npm two-factor authentication** — there is no CI/token-based publish. This is a deliberate anti-worm choice: it keeps publishing credentials off CI (a prime target for self-propagating worms that harvest CI/CD secrets) and behind a human MFA prompt. npm provenance / OIDC publishing was evaluated and **deferred** for that reason — adopting it would relocate publishing into automated CI and trade the human MFA gate for a long-lived automated trust relationship. It remains a deliberate future decision, not a default.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+# SECURITY — allowBuilds is a supply-chain allowlist. pnpm 10+ blocks ALL
+# dependency lifecycle scripts (postinstall, etc.) by default; that default is
+# the primary defense against Shai-Hulud-class npm worms. Only packages listed
+# below (= true) may run install/build scripts. Keep this MINIMAL — every entry
+# re-opens script execution for that package, so add one only with clear cause.
 allowBuilds:
   esbuild: true
   msgpackr-extract: true


### PR DESCRIPTION
Part of the cross-repo **Psychic ecosystem security hardening** effort — the `psychic-workers` slice. Siblings: `dream` #704, `psychic` #506, and the `psychic-websockets` PR. No Bun/Deno runtime changes here (isolated to dream/psychic/create-psychic); this repo carries only the supply-chain hardening.

## What's here (items 1–2, 6)
- Document the `allowBuilds` dependency build-script allowlist rationale in `pnpm-workspace.yaml`.
- Raise the npm release-age cooldown to 3 days (`.npmrc`) + a CI invariant (`pr-checks.yml`) that keeps the cooldown-bypass list restricted to `@rvoh/*`.
- `SECURITY.md`: supply-chain posture + the deliberate local+MFA publishing choice.

## Verification
`pnpm lint` clean. Changes are config/docs only (no `src/`); CI runs the full build + spec suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)