### PR TITLE
Bump patch version for GitHub npm publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.4.0
+## 2.3.1
 
 - switch to Github action publishing to npmjs.com
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0
+
+- switch to Github action publishing to npmjs.com
+
 ## 2.3.0
 
 support psychic v3

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic-workers",
   "description": "Background job system for Psychic applications",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "author": "RVO Health",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic-workers",
   "description": "Background job system for Psychic applications",
-  "version": "2.4.0",
+  "version": "2.3.1",
   "author": "RVO Health",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Bumps the package minor version for GitHub releases and signed provenance when publishing to npmjs.com.