### PR TITLE
Worker fatal-error and signal exit correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fix: worker processes started via `background.work()` now exit with code 1 after an `uncaughtException` or `unhandledRejection` (after best-effort graceful shutdown bounded by a 15s timeout), so orchestrators restart them instead of leaving a broken process alive
 - fix: a failing or hung graceful shutdown on SIGTERM/SIGINT now logs and exits with code 1 instead of leaving the process ignoring signals until SIGKILL; clean shutdown still exits 0
 - fix: one rejecting `worker.close()` no longer aborts closing the remaining workers and quitting redis connections during shutdown
+- `doWork` now throws `NoClassForSpecifiedGlobalName` (exported from `@rvoh/psychic-workers/errors`) when a job's `globalName` no longer resolves to a class, so the job lands in BullMQ's failed set instead of silently completing. Previously, after a class rename/removal, queued jobs and repeating job schedulers referencing the old name would no-op forever with no log, failure, or metric. When the class resolves but the model instance is not found, the job still completes quietly (the record may have been legitimately deleted).
 
 ## 2.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.4.0
+
+- fix: worker processes started via `background.work()` now exit with code 1 after an `uncaughtException` or `unhandledRejection` (after best-effort graceful shutdown bounded by a 15s timeout), so orchestrators restart them instead of leaving a broken process alive
+- fix: a failing or hung graceful shutdown on SIGTERM/SIGINT now logs and exits with code 1 instead of leaving the process ignoring signals until SIGKILL; clean shutdown still exits 0
+- fix: one rejecting `worker.close()` no longer aborts closing the remaining workers and quitting redis connections during shutdown
+
 ## 2.3.2
 
 - upgrade to pnpm@11.9.0; add strictDepBuilds: false and deny esbuild/msgpackr-extract/puppeteer build scripts in pnpm-workspace.yaml

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@rvoh/psychic-workers",
   "description": "Background job system for Psychic applications",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "author": "RVO Health",
   "publishConfig": {
     "access": "public"

--- a/spec/unit/background/closeAllRedisConnections.spec.ts
+++ b/spec/unit/background/closeAllRedisConnections.spec.ts
@@ -1,0 +1,22 @@
+import { Worker } from 'bullmq'
+import { Background } from '../../../src/package-exports/index.js'
+
+describe('Background#closeAllRedisConnections', () => {
+  context('when closing one worker rejects', () => {
+    it('still closes the remaining workers', async () => {
+      const backgroundInstance = new Background()
+
+      const failingWorker = { close: vi.fn().mockRejectedValue(new Error('redis down')) }
+      const healthyWorker = { close: vi.fn().mockResolvedValue(undefined) }
+      ;(backgroundInstance as unknown as { _workers: unknown[] })._workers = [
+        failingWorker as unknown as Worker,
+        healthyWorker as unknown as Worker,
+      ]
+
+      await backgroundInstance.closeAllRedisConnections()
+
+      expect(failingWorker.close).toHaveBeenCalled()
+      expect(healthyWorker.close).toHaveBeenCalled()
+    })
+  })
+})

--- a/spec/unit/background/doWork.spec.ts
+++ b/spec/unit/background/doWork.spec.ts
@@ -1,0 +1,97 @@
+import { Job } from 'bullmq'
+import background, { Background } from '../../../src/background/index.js'
+import NoClassForSpecifiedGlobalName from '../../../src/error/background/NoClassForSpecifiedGlobalName.js'
+import { BackgroundJobData, JobTypes } from '../../../src/types/background.js'
+import createUser from '../../../test-app/spec/factories/UserFactory.js'
+import User from '../../../test-app/src/app/models/User.js'
+
+describe('background (app singleton)', () => {
+  describe('.doWork', () => {
+    function buildJob(jobType: JobTypes, jobData: BackgroundJobData) {
+      const queue = new Background.Queue('TestQueue', { connection: {} })
+      return new Job(queue, jobType, jobData, {})
+    }
+
+    context('BackgroundJobQueueStaticJob', () => {
+      context('when the globalName no longer resolves to a class', () => {
+        it('throws NoClassForSpecifiedGlobalName so the job is marked failed rather than completed', async () => {
+          const job = buildJob('BackgroundJobQueueStaticJob', {
+            globalName: 'services/ClassThatNoLongerExists',
+            method: 'classRunInBG',
+            args: ['bottlearum'],
+          })
+
+          await expect(background.doWork(job)).rejects.toThrow(NoClassForSpecifiedGlobalName)
+        })
+
+        it('includes the unresolvable globalName in the error message', async () => {
+          const job = buildJob('BackgroundJobQueueStaticJob', {
+            globalName: 'services/ClassThatNoLongerExists',
+            method: 'classRunInBG',
+            args: ['bottlearum'],
+          })
+
+          await expect(background.doWork(job)).rejects.toThrow('services/ClassThatNoLongerExists')
+        })
+      })
+
+      context('when the job data is missing a globalName', () => {
+        it('throws NoClassForSpecifiedGlobalName', async () => {
+          const job = buildJob('BackgroundJobQueueStaticJob', {
+            method: 'classRunInBG',
+            args: ['bottlearum'],
+          })
+
+          await expect(background.doWork(job)).rejects.toThrow(NoClassForSpecifiedGlobalName)
+        })
+      })
+    })
+
+    context('BackgroundJobQueueModelInstanceJob', () => {
+      context('when the globalName no longer resolves to a class', () => {
+        it('throws NoClassForSpecifiedGlobalName so the job is marked failed rather than completed', async () => {
+          const job = buildJob('BackgroundJobQueueModelInstanceJob', {
+            globalName: 'ModelThatNoLongerExists',
+            id: '123',
+            method: 'testBackground',
+            args: ['howyadoin'],
+          })
+
+          await expect(background.doWork(job)).rejects.toThrow(NoClassForSpecifiedGlobalName)
+        })
+      })
+
+      context('when the model instance is not found', () => {
+        it('returns without error (the record may have been legitimately deleted)', async () => {
+          const job = buildJob('BackgroundJobQueueModelInstanceJob', {
+            globalName: 'User',
+            id: '9999999',
+            method: 'testBackground',
+            args: ['howyadoin'],
+          })
+
+          await expect(background.doWork(job)).resolves.toBeUndefined()
+        })
+      })
+
+      context('when the class resolves and the model instance is found', () => {
+        it('calls the specified method on the instance', async () => {
+          const user = await createUser()
+          vi.spyOn(User.prototype, '_testBackground')
+
+          const job = buildJob('BackgroundJobQueueModelInstanceJob', {
+            globalName: 'User',
+            id: user.id,
+            method: 'testBackground',
+            args: ['howyadoin'],
+          })
+
+          await background.doWork(job)
+
+          // eslint-disable-next-line @typescript-eslint/unbound-method
+          expect(User.prototype._testBackground).toHaveBeenCalledWith(user.id, 'howyadoin', job)
+        })
+      })
+    })
+  })
+})

--- a/spec/unit/background/work.spec.ts
+++ b/spec/unit/background/work.spec.ts
@@ -99,4 +99,40 @@ describe('Background#work process event handling', () => {
       expect(shutdownSpy).toHaveBeenCalled()
     })
   })
+
+  for (const signal of ['SIGTERM', 'SIGINT'] as const) {
+    context(signal, () => {
+      it('exits with code 0 after clean graceful shutdown', async () => {
+        const shutdownSpy = vi.spyOn(backgroundInstance, 'shutdown').mockResolvedValue(undefined)
+
+        handlers[signal]!()
+
+        await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(0))
+        expect(shutdownSpy).toHaveBeenCalled()
+      })
+
+      context('when graceful shutdown rejects', () => {
+        it('exits with code 1 instead of leaving the process alive', async () => {
+          vi.spyOn(backgroundInstance, 'shutdown').mockRejectedValue(new Error('shutdown failure'))
+
+          handlers[signal]!()
+
+          await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(1))
+        })
+      })
+
+      context('when graceful shutdown hangs', () => {
+        it('exits with code 1 once the shutdown timeout elapses', async () => {
+          vi.useFakeTimers()
+          vi.spyOn(backgroundInstance, 'shutdown').mockImplementation(() => new Promise(() => {}))
+
+          handlers[signal]!()
+
+          await vi.advanceTimersByTimeAsync(Background.SHUTDOWN_TIMEOUT_MS)
+          expect(exitSpy).toHaveBeenCalledWith(1)
+          vi.useRealTimers()
+        })
+      })
+    })
+  }
 })

--- a/spec/unit/background/work.spec.ts
+++ b/spec/unit/background/work.spec.ts
@@ -1,0 +1,102 @@
+import { PsychicApp } from '@rvoh/psychic'
+import { Queue, Worker } from 'bullmq'
+import { Background } from '../../../src/package-exports/index.js'
+
+describe('Background#work process event handling', () => {
+  class QueueStub {
+    close() {
+      return null
+    }
+  }
+
+  class WorkerStub {
+    close() {
+      return null
+    }
+  }
+
+  let backgroundInstance: Background
+  let exitSpy: ReturnType<typeof vi.spyOn>
+  let handlers: Record<string, (...args: unknown[]) => void>
+
+  beforeEach(() => {
+    vi.spyOn(Background, 'Queue', 'get').mockReturnValue(QueueStub as unknown as typeof Queue)
+    vi.spyOn(Background, 'Worker', 'get').mockReturnValue(WorkerStub as unknown as typeof Worker)
+    vi.spyOn(PsychicApp, 'log').mockReturnValue(undefined)
+    vi.spyOn(PsychicApp, 'logWithLevel').mockReturnValue(undefined)
+
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never) as ReturnType<
+      typeof vi.spyOn
+    >
+
+    handlers = {}
+    vi.spyOn(process, 'on').mockImplementation(((event: string, handler: (...args: unknown[]) => void) => {
+      handlers[event] = handler
+      return process
+    }) as typeof process.on)
+
+    backgroundInstance = new Background()
+    backgroundInstance.work()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  context('uncaughtException', () => {
+    it('attempts graceful shutdown, then exits with code 1', async () => {
+      const shutdownSpy = vi.spyOn(backgroundInstance, 'shutdown').mockResolvedValue(undefined)
+
+      handlers['uncaughtException']!(new Error('uncaught exception'))
+
+      await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(1))
+      expect(shutdownSpy).toHaveBeenCalled()
+    })
+
+    context('when graceful shutdown rejects', () => {
+      it('still exits with code 1', async () => {
+        vi.spyOn(backgroundInstance, 'shutdown').mockRejectedValue(new Error('shutdown failure'))
+
+        handlers['uncaughtException']!(new Error('uncaught exception'))
+
+        await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(1))
+      })
+    })
+
+    context('when graceful shutdown hangs', () => {
+      it('exits with code 1 once the shutdown timeout elapses', async () => {
+        vi.useFakeTimers()
+        vi.spyOn(backgroundInstance, 'shutdown').mockImplementation(() => new Promise(() => {}))
+
+        handlers['uncaughtException']!(new Error('uncaught exception'))
+
+        await vi.advanceTimersByTimeAsync(Background.SHUTDOWN_TIMEOUT_MS)
+        expect(exitSpy).toHaveBeenCalledWith(1)
+        vi.useRealTimers()
+      })
+    })
+
+    context('when a second fatal error arrives during cleanup', () => {
+      it('exits immediately with code 1', async () => {
+        vi.spyOn(backgroundInstance, 'shutdown').mockImplementation(() => new Promise(() => {}))
+
+        handlers['uncaughtException']!(new Error('first fatal error'))
+        expect(exitSpy).not.toHaveBeenCalled()
+
+        handlers['uncaughtException']!(new Error('second fatal error'))
+        await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(1))
+      })
+    })
+  })
+
+  context('unhandledRejection', () => {
+    it('attempts graceful shutdown, then exits with code 1', async () => {
+      const shutdownSpy = vi.spyOn(backgroundInstance, 'shutdown').mockResolvedValue(undefined)
+
+      handlers['unhandledRejection']!(new Error('unhandled rejection'))
+
+      await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(1))
+      expect(shutdownSpy).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -200,16 +200,17 @@ export class Background {
   private fatalErrorShutdownBegun = false
 
   private async shutdownAndExit() {
+    let exitCode = 0
+
     try {
       await this.shutdownWithTimeout()
     } catch (error) {
       PsychicApp.logWithLevel('error', '[psychic-workers] error during graceful shutdown:', error)
-      process.exit(1)
-      return
+      exitCode = 1
     }
 
     // https://docs.bullmq.io/guide/going-to-production#gracefully-shut-down-workers
-    process.exit(0)
+    process.exit(exitCode)
   }
 
   /**
@@ -220,20 +221,18 @@ export class Background {
    * then exit nonzero so orchestrators know to restart the process
    */
   private async shutdownAndExitAfterFatalError() {
-    if (this.fatalErrorShutdownBegun) {
-      process.exit(1)
-      return
-    }
-    this.fatalErrorShutdownBegun = true
+    if (!this.fatalErrorShutdownBegun) {
+      this.fatalErrorShutdownBegun = true
 
-    try {
-      await this.shutdownWithTimeout()
-    } catch (error) {
-      PsychicApp.logWithLevel(
-        'error',
-        '[psychic-workers] error during graceful shutdown after fatal error:',
-        error,
-      )
+      try {
+        await this.shutdownWithTimeout()
+      } catch (error) {
+        PsychicApp.logWithLevel(
+          'error',
+          '[psychic-workers] error during graceful shutdown after fatal error:',
+          error,
+        )
+      }
     }
 
     process.exit(1)

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -15,6 +15,7 @@ import ActivatingBackgroundWorkersWithoutDefaultWorkerConnection from '../error/
 import ActivatingNamedQueueBackgroundWorkersWithoutWorkerConnection from '../error/background/ActivatingNamedQueueBackgroundWorkersWithoutWorkerConnection.js'
 import DefaultBullMQNativeOptionsMissingQueueConnectionAndDefaultQueueConnection from '../error/background/DefaultBullMQNativeOptionsMissingQueueConnectionAndDefaultQueueConnection.js'
 import NamedBullMQNativeOptionsMissingQueueConnectionAndDefaultQueueConnection from '../error/background/NamedBullMQNativeOptionsMissingQueueConnectionAndDefaultQueueConnection.js'
+import NoClassForSpecifiedGlobalName from '../error/background/NoClassForSpecifiedGlobalName.js'
 import NoQueueForSpecifiedQueueName from '../error/background/NoQueueForSpecifiedQueueName.js'
 import NoQueueForSpecifiedWorkstream from '../error/background/NoQueueForSpecifiedWorkstream.js'
 import EnvInternal from '../helpers/EnvInternal.js'
@@ -913,25 +914,26 @@ export class Background {
           objectClass = PsychicApp.lookupClassByGlobalName(globalName)
         }
 
-        if (!objectClass) return
+        if (!objectClass) throw new NoClassForSpecifiedGlobalName(globalName)
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         await objectClass[method!](...args, job)
         break
 
-      case 'BackgroundJobQueueModelInstanceJob':
+      case 'BackgroundJobQueueModelInstanceJob': {
         if (globalName) {
           dreamClass = PsychicApp.lookupClassByGlobalName(globalName) as typeof Dream | undefined
         }
 
-        if (dreamClass) {
-          const modelInstance = await dreamClass.connection('primary').find(id)
-          if (!modelInstance) return
+        if (!dreamClass) throw new NoClassForSpecifiedGlobalName(globalName)
 
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-          await (modelInstance as any)[method!](...args, job)
-        }
+        const modelInstance = await dreamClass.connection('primary').find(id)
+        if (!modelInstance) return
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        await (modelInstance as any)[method!](...args, job)
         break
+      }
     }
   }
 }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -283,7 +283,12 @@ export class Background {
     if (!EnvInternal.isTest) PsychicApp.log(`[psychic-workers] closeAllRedisConnections`)
 
     for (const worker of this.workers) {
-      await worker.close()
+      try {
+        await worker.close()
+      } catch (error) {
+        if (!EnvInternal.isTest)
+          PsychicApp.logWithLevel('error', `[psychic-workers] error closing worker:`, error)
+      }
     }
 
     for (const connection of this.redisConnections) {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -200,7 +200,14 @@ export class Background {
   private fatalErrorShutdownBegun = false
 
   private async shutdownAndExit() {
-    await this.shutdown()
+    try {
+      await this.shutdownWithTimeout()
+    } catch (error) {
+      PsychicApp.logWithLevel('error', '[psychic-workers] error during graceful shutdown:', error)
+      process.exit(1)
+      return
+    }
+
     // https://docs.bullmq.io/guide/going-to-production#gracefully-shut-down-workers
     process.exit(0)
   }
@@ -572,16 +579,12 @@ export class Background {
       if (!EnvInternal.isTest) PsychicApp.log('[psychic-workers] handle SIGTERM')
 
       void this.shutdownAndExit()
-        .then(() => {})
-        .catch(() => {})
     })
 
     process.on('SIGINT', () => {
       if (!EnvInternal.isTest) PsychicApp.log('[psychic-workers] handle SIGINT')
 
       void this.shutdownAndExit()
-        .then(() => {})
-        .catch(() => {})
     })
 
     this.connect({ activateWorkers: true })

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -181,10 +181,78 @@ export class Background {
     return [...this._workers]
   }
 
+  /**
+   * @internal
+   *
+   * the maximum number of milliseconds graceful shutdown is allowed
+   * to run before the process exits anyway, so that a hung hook,
+   * db close, or worker close can never keep a dying process alive
+   */
+  public static readonly SHUTDOWN_TIMEOUT_MS = 15000
+
+  /**
+   * @internal
+   *
+   * set once a fatal error has begun graceful cleanup, so that a
+   * second fatal error during cleanup exits immediately instead of
+   * attempting cleanup again
+   */
+  private fatalErrorShutdownBegun = false
+
   private async shutdownAndExit() {
     await this.shutdown()
     // https://docs.bullmq.io/guide/going-to-production#gracefully-shut-down-workers
     process.exit(0)
+  }
+
+  /**
+   * @internal
+   *
+   * after an uncaught exception or unhandled rejection, attempt
+   * best-effort graceful cleanup (bounded by SHUTDOWN_TIMEOUT_MS),
+   * then exit nonzero so orchestrators know to restart the process
+   */
+  private async shutdownAndExitAfterFatalError() {
+    if (this.fatalErrorShutdownBegun) {
+      process.exit(1)
+      return
+    }
+    this.fatalErrorShutdownBegun = true
+
+    try {
+      await this.shutdownWithTimeout()
+    } catch (error) {
+      PsychicApp.logWithLevel(
+        'error',
+        '[psychic-workers] error during graceful shutdown after fatal error:',
+        error,
+      )
+    }
+
+    process.exit(1)
+  }
+
+  /**
+   * @internal
+   *
+   * runs {@link Background.shutdown}, rejecting if it has not settled
+   * within SHUTDOWN_TIMEOUT_MS
+   */
+  private async shutdownWithTimeout() {
+    await Promise.race([
+      this.shutdown(),
+      new Promise<never>((_, reject) => {
+        setTimeout(
+          () =>
+            reject(
+              new Error(
+                `[psychic-workers] graceful shutdown timed out after ${Background.SHUTDOWN_TIMEOUT_MS}ms`,
+              ),
+            ),
+          Background.SHUTDOWN_TIMEOUT_MS,
+        ).unref()
+      }),
+    ])
   }
 
   /**
@@ -491,11 +559,13 @@ export class Background {
    */
   public work() {
     process.on('uncaughtException', (error: Error) => {
-      PsychicApp.log('[psychic-workers] uncaughtException:', error)
+      PsychicApp.logWithLevel('error', '[psychic-workers] uncaughtException:', error)
+      void this.shutdownAndExitAfterFatalError()
     })
 
-    process.on('unhandledRejection', (error: Error) => {
-      PsychicApp.log('[psychic-workers] unhandledRejection:', error)
+    process.on('unhandledRejection', (reason: unknown) => {
+      PsychicApp.logWithLevel('error', '[psychic-workers] unhandledRejection:', reason)
+      void this.shutdownAndExitAfterFatalError()
     })
 
     process.on('SIGTERM', () => {

--- a/src/error/background/NoClassForSpecifiedGlobalName.ts
+++ b/src/error/background/NoClassForSpecifiedGlobalName.ts
@@ -1,0 +1,14 @@
+export default class NoClassForSpecifiedGlobalName extends Error {
+  constructor(private globalName: string | undefined) {
+    super()
+  }
+
+  public override get message() {
+    return `Error processing background job
+No class found for globalName "${this.globalName}"
+
+This usually means the class was renamed or removed after this job
+(or its repeating job scheduler) was enqueued.
+`
+  }
+}

--- a/src/package-exports/errors.ts
+++ b/src/package-exports/errors.ts
@@ -1,2 +1,3 @@
+export { default as NoClassForSpecifiedGlobalName } from '../error/background/NoClassForSpecifiedGlobalName.js'
 export { default as NoQueueForSpecifiedQueueName } from '../error/background/NoQueueForSpecifiedQueueName.js'
 export { default as NoQueueForSpecifiedWorkstream } from '../error/background/NoQueueForSpecifiedWorkstream.js'

--- a/test-app/src/conf/app.ts
+++ b/test-app/src/conf/app.ts
@@ -26,7 +26,7 @@ export default async (psy: PsychicApp) => {
   // set options to pass to coors when middleware is booted
   psy.set('cors', {
     credentials: true,
-    origin: [process.env.CLIENT_HOST || 'http://localhost:3000'],
+    origin: process.env.CLIENT_HOST || 'http://localhost:3000',
   })
 
   // set options for cookie usage

--- a/test-app/src/conf/dream.ts
+++ b/test-app/src/conf/dream.ts
@@ -32,7 +32,7 @@ export default async function configureDream(app: DreamApp) {
       host: process.env.DB_HOST!,
       name: process.env.DB_NAME!,
       port: parseInt(process.env.DB_PORT!),
-      ssl: process.env.DB_USE_SSL === '1',
+      useSsl: process.env.DB_USE_SSL === '1',
     },
   })
 }


### PR DESCRIPTION
## What this does

Worker processes started via `background.work()` now behave correctly when things go fatally wrong:

- **`uncaughtException` / `unhandledRejection` exit 1.** Previously these handlers only logged, suppressing Node's default crash behavior and leaving a broken worker alive indefinitely. Now the process attempts best-effort graceful shutdown (the existing `shutdown()` path: `workerShutdown` hooks, db close, worker close, redis quit), bounded by a 15s timeout so a hung close can never keep a dying process alive, then exits with code 1 so orchestrators restart it. A second fatal error during cleanup exits immediately.
- **SIGTERM/SIGINT can no longer hang the process.** The signal handlers swallowed every shutdown rejection (`.catch(() => {})`), so a throwing `workerShutdown` hook meant `process.exit` never ran — and since a signal handler was installed, Node's default die-on-signal was disabled: the worker ignored SIGTERM until SIGKILL with zero diagnostics. Failed or hung graceful shutdown now logs at error level and exits 1; clean shutdown still exits 0.
- **`closeAllRedisConnections` close-loop robustness.** One rejecting `worker.close()` no longer aborts closing the remaining workers and quitting redis connections; worker closes get the same per-item try/catch as the redis quit loop.
- **Pre-existing `build:test-app` drift fixed** (`ssl` → `useSsl` db credential key; cors `origin` array → string) — failed on a clean checkout of main; CI only runs `pnpm build`, which is why it never surfaced.

## Verification

- `pnpm lint` ✅
- `pnpm build` / `pnpm build:test-app` ✅
- `pnpm uspec` ✅ (12 files, 65 specs — includes new specs for every behavior above, written failing-first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)