### PR TITLE
doWork: fail jobs whose class no longer resolves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fix: worker processes started via `background.work()` now exit with code 1 after an `uncaughtException` or `unhandledRejection` (after best-effort graceful shutdown bounded by a 15s timeout), so orchestrators restart them instead of leaving a broken process alive
 - fix: a failing or hung graceful shutdown on SIGTERM/SIGINT now logs and exits with code 1 instead of leaving the process ignoring signals until SIGKILL; clean shutdown still exits 0
 - fix: one rejecting `worker.close()` no longer aborts closing the remaining workers and quitting redis connections during shutdown
+- `doWork` now throws `NoClassForSpecifiedGlobalName` (exported from `@rvoh/psychic-workers/errors`) when a job's `globalName` no longer resolves to a class, so the job lands in BullMQ's failed set instead of silently completing. Previously, after a class rename/removal, queued jobs and repeating job schedulers referencing the old name would no-op forever with no log, failure, or metric. When the class resolves but the model instance is not found, the job still completes quietly (the record may have been legitimately deleted).
 
 ## 2.3.2
 

--- a/spec/unit/background/doWork.spec.ts
+++ b/spec/unit/background/doWork.spec.ts
@@ -1,0 +1,97 @@
+import { Job } from 'bullmq'
+import background, { Background } from '../../../src/background/index.js'
+import NoClassForSpecifiedGlobalName from '../../../src/error/background/NoClassForSpecifiedGlobalName.js'
+import { BackgroundJobData, JobTypes } from '../../../src/types/background.js'
+import createUser from '../../../test-app/spec/factories/UserFactory.js'
+import User from '../../../test-app/src/app/models/User.js'
+
+describe('background (app singleton)', () => {
+  describe('.doWork', () => {
+    function buildJob(jobType: JobTypes, jobData: BackgroundJobData) {
+      const queue = new Background.Queue('TestQueue', { connection: {} })
+      return new Job(queue, jobType, jobData, {})
+    }
+
+    context('BackgroundJobQueueStaticJob', () => {
+      context('when the globalName no longer resolves to a class', () => {
+        it('throws NoClassForSpecifiedGlobalName so the job is marked failed rather than completed', async () => {
+          const job = buildJob('BackgroundJobQueueStaticJob', {
+            globalName: 'services/ClassThatNoLongerExists',
+            method: 'classRunInBG',
+            args: ['bottlearum'],
+          })
+
+          await expect(background.doWork(job)).rejects.toThrow(NoClassForSpecifiedGlobalName)
+        })
+
+        it('includes the unresolvable globalName in the error message', async () => {
+          const job = buildJob('BackgroundJobQueueStaticJob', {
+            globalName: 'services/ClassThatNoLongerExists',
+            method: 'classRunInBG',
+            args: ['bottlearum'],
+          })
+
+          await expect(background.doWork(job)).rejects.toThrow('services/ClassThatNoLongerExists')
+        })
+      })
+
+      context('when the job data is missing a globalName', () => {
+        it('throws NoClassForSpecifiedGlobalName', async () => {
+          const job = buildJob('BackgroundJobQueueStaticJob', {
+            method: 'classRunInBG',
+            args: ['bottlearum'],
+          })
+
+          await expect(background.doWork(job)).rejects.toThrow(NoClassForSpecifiedGlobalName)
+        })
+      })
+    })
+
+    context('BackgroundJobQueueModelInstanceJob', () => {
+      context('when the globalName no longer resolves to a class', () => {
+        it('throws NoClassForSpecifiedGlobalName so the job is marked failed rather than completed', async () => {
+          const job = buildJob('BackgroundJobQueueModelInstanceJob', {
+            globalName: 'ModelThatNoLongerExists',
+            id: '123',
+            method: 'testBackground',
+            args: ['howyadoin'],
+          })
+
+          await expect(background.doWork(job)).rejects.toThrow(NoClassForSpecifiedGlobalName)
+        })
+      })
+
+      context('when the model instance is not found', () => {
+        it('returns without error (the record may have been legitimately deleted)', async () => {
+          const job = buildJob('BackgroundJobQueueModelInstanceJob', {
+            globalName: 'User',
+            id: '9999999',
+            method: 'testBackground',
+            args: ['howyadoin'],
+          })
+
+          await expect(background.doWork(job)).resolves.toBeUndefined()
+        })
+      })
+
+      context('when the class resolves and the model instance is found', () => {
+        it('calls the specified method on the instance', async () => {
+          const user = await createUser()
+          vi.spyOn(User.prototype, '_testBackground')
+
+          const job = buildJob('BackgroundJobQueueModelInstanceJob', {
+            globalName: 'User',
+            id: user.id,
+            method: 'testBackground',
+            args: ['howyadoin'],
+          })
+
+          await background.doWork(job)
+
+          // eslint-disable-next-line @typescript-eslint/unbound-method
+          expect(User.prototype._testBackground).toHaveBeenCalledWith(user.id, 'howyadoin', job)
+        })
+      })
+    })
+  })
+})

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -15,6 +15,7 @@ import ActivatingBackgroundWorkersWithoutDefaultWorkerConnection from '../error/
 import ActivatingNamedQueueBackgroundWorkersWithoutWorkerConnection from '../error/background/ActivatingNamedQueueBackgroundWorkersWithoutWorkerConnection.js'
 import DefaultBullMQNativeOptionsMissingQueueConnectionAndDefaultQueueConnection from '../error/background/DefaultBullMQNativeOptionsMissingQueueConnectionAndDefaultQueueConnection.js'
 import NamedBullMQNativeOptionsMissingQueueConnectionAndDefaultQueueConnection from '../error/background/NamedBullMQNativeOptionsMissingQueueConnectionAndDefaultQueueConnection.js'
+import NoClassForSpecifiedGlobalName from '../error/background/NoClassForSpecifiedGlobalName.js'
 import NoQueueForSpecifiedQueueName from '../error/background/NoQueueForSpecifiedQueueName.js'
 import NoQueueForSpecifiedWorkstream from '../error/background/NoQueueForSpecifiedWorkstream.js'
 import EnvInternal from '../helpers/EnvInternal.js'
@@ -913,25 +914,26 @@ export class Background {
           objectClass = PsychicApp.lookupClassByGlobalName(globalName)
         }
 
-        if (!objectClass) return
+        if (!objectClass) throw new NoClassForSpecifiedGlobalName(globalName)
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         await objectClass[method!](...args, job)
         break
 
-      case 'BackgroundJobQueueModelInstanceJob':
+      case 'BackgroundJobQueueModelInstanceJob': {
         if (globalName) {
           dreamClass = PsychicApp.lookupClassByGlobalName(globalName) as typeof Dream | undefined
         }
 
-        if (dreamClass) {
-          const modelInstance = await dreamClass.connection('primary').find(id)
-          if (!modelInstance) return
+        if (!dreamClass) throw new NoClassForSpecifiedGlobalName(globalName)
 
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-          await (modelInstance as any)[method!](...args, job)
-        }
+        const modelInstance = await dreamClass.connection('primary').find(id)
+        if (!modelInstance) return
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        await (modelInstance as any)[method!](...args, job)
         break
+      }
     }
   }
 }

--- a/src/error/background/NoClassForSpecifiedGlobalName.ts
+++ b/src/error/background/NoClassForSpecifiedGlobalName.ts
@@ -1,0 +1,14 @@
+export default class NoClassForSpecifiedGlobalName extends Error {
+  constructor(private globalName: string | undefined) {
+    super()
+  }
+
+  public override get message() {
+    return `Error processing background job
+No class found for globalName "${this.globalName}"
+
+This usually means the class was renamed or removed after this job
+(or its repeating job scheduler) was enqueued.
+`
+  }
+}

--- a/src/package-exports/errors.ts
+++ b/src/package-exports/errors.ts
@@ -1,2 +1,3 @@
+export { default as NoClassForSpecifiedGlobalName } from '../error/background/NoClassForSpecifiedGlobalName.js'
 export { default as NoQueueForSpecifiedQueueName } from '../error/background/NoQueueForSpecifiedQueueName.js'
 export { default as NoQueueForSpecifiedWorkstream } from '../error/background/NoQueueForSpecifiedWorkstream.js'


### PR DESCRIPTION
## What

`doWork` now throws a typed `NoClassForSpecifiedGlobalName` error when a job's `globalName` no longer resolves to a class, for both `BackgroundJobQueueStaticJob` and `BackgroundJobQueueModelInstanceJob`. The job lands in BullMQ's failed set (visible to `worker.on('failed')` wiring) instead of being silently marked completed.

## Why

After a class rename/removal deploy, queued jobs — and repeating job schedulers registered via `upsertJobScheduler`, which are never cleaned up — would no-op on every tick with no log, no failure, and no metric.

## What is unchanged

- The model-instance-not-found path: when the class resolves but the record is missing, the job still completes quietly, since the record may have been legitimately deleted.

## Notes

- `NoClassForSpecifiedGlobalName` is exported from the `errors` package export.
- Includes the same pre-existing test-app type-drift fix as #73 (`ssl` → `useSsl`, cors `origin` array → string) so `pnpm build:test-app` compiles from a clean checkout of main; identical hunks, so the branches merge cleanly whichever lands first.

## Verification

- `pnpm lint` ✅
- `pnpm build` ✅
- `pnpm build:test-app` ✅
- `pnpm uspec` ✅ (11 files / 59 specs, including 6 new `doWork` specs written failing-first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)